### PR TITLE
chore(config): 스프링 프로필 활성화 수정

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -25,8 +25,8 @@ services:
       - .env
 
     environment:
-      - SPRING_PROFILES_ACTIVE=prod
-      -
+      SPRING_PROFILES_ACTIVE: prod
+
     volumes:
       - gradle-cache:/root/.gradle
 


### PR DESCRIPTION
## **⚠️ 연관된 이슈**

- Closes: #6 

## **✔️ 작업 내용**

compose.yaml에서 기존
environment: - SPRING_PROFILES_ACTIVE=prod 
의 경우 docker compose에서 SPRING_PROFILES_ACTIVE을 SPRING_PROFILES_ACTIVE=prod로 인식하므로

environment: SPRING_PROFILES_ACTIVE: prod
다음과 같이 수정