### PR TITLE
feat: 게시글 및 태그 엔티티 구조 구현 

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/EmotionmusicapiApplication.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/EmotionmusicapiApplication.java
@@ -1,11 +1,7 @@
 package cloud.emusic.emotionmusicapi;
 
-import cloud.emusic.emotionmusicapi.service.UserService;
-import io.github.cdimascio.dotenv.Dotenv;
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
@@ -15,14 +11,4 @@ public class EmotionmusicapiApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(EmotionmusicapiApplication.class, args);
 	}
-
-	@Bean
-	public CommandLineRunner commandLineRunner(UserService userService) {
-		return args -> {
-			System.out.println("===== Inserting Test User Data =====");
-			userService.signUp();
-			System.out.println("====================================");
-		};
-	}
-
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/DayTag.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/DayTag.java
@@ -23,6 +23,10 @@ public class DayTag {
     @Column(nullable = false,length = 500)
     private String name;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
     @CreationTimestamp
     private LocalDateTime createdAt;
 

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/DayTag.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/DayTag.java
@@ -1,0 +1,31 @@
+package cloud.emusic.emotionmusicapi.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "day_tag")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DayTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "day_tag_id")
+    private Long id;
+
+    @Column(nullable = false,length = 500)
+    private String name;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/EmotionTag.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/EmotionTag.java
@@ -1,6 +1,7 @@
 package cloud.emusic.emotionmusicapi.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Table(name = "emotion_tag")
-@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EmotionTag {
 
     @Id

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/EmotionTag.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/EmotionTag.java
@@ -1,0 +1,29 @@
+package cloud.emusic.emotionmusicapi.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "emotion_tag")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class EmotionTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "emotion_tag_id")
+    private Long id;
+
+    @Column(nullable = false,unique = true,length = 100)
+    private String name;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/Post.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/Post.java
@@ -1,0 +1,38 @@
+package cloud.emusic.emotionmusicapi.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "post")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class Post {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DayTag> dayTags = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostEmotionTag> emotionTags = new ArrayList<>();
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/Post.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/Post.java
@@ -1,6 +1,7 @@
 package cloud.emusic.emotionmusicapi.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
@@ -12,7 +13,7 @@ import java.util.List;
 @Entity
 @Getter
 @Table(name = "post")
-@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
 
     @Id

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/Post.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/Post.java
@@ -25,9 +25,6 @@ public class Post {
     private User user;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<DayTag> dayTags = new ArrayList<>();
-
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostEmotionTag> emotionTags = new ArrayList<>();
 
     @CreationTimestamp

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/PostEmotionTag.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/PostEmotionTag.java
@@ -6,7 +6,10 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "post_emotion_tag")
+@Table(
+        name = "post_emotion_tag",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "emotion_tag_id"}) // 중복 방지
+)
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class PostEmotionTag {
 
@@ -14,6 +17,10 @@ public class PostEmotionTag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_emotion_tag_id")
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "emotion_tag_id", nullable = false)

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/PostEmotionTag.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/PostEmotionTag.java
@@ -1,0 +1,21 @@
+package cloud.emusic.emotionmusicapi.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "post_emotion_tag")
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class PostEmotionTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_emotion_tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "emotion_tag_id", nullable = false)
+    private EmotionTag emotionTag;
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/PostEmotionTag.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/PostEmotionTag.java
@@ -1,6 +1,7 @@
 package cloud.emusic.emotionmusicapi.domain;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
         name = "post_emotion_tag",
         uniqueConstraints = @UniqueConstraint(columnNames = {"post_id", "emotion_tag_id"}) // 중복 방지
 )
-@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PostEmotionTag {
 
     @Id


### PR DESCRIPTION
## ⚠️ 연관된 이슈

- close #10 

## ✔️ 작업 내용

### 1. 엔티티 설계 및 매핑

- 복합키 설계

PostEmotionTag 엔티티에 @EmbeddedId 기반 복합키 적용
post_id, emotion_tag_id 조합으로 유니크 보장

- 연관관계 매핑

Post ↔ PostEmotionTag : 1:N 양방향 매핑
EmotionTag ↔ PostEmotionTag : 1:N 매핑
User ↔ Post : 1:N 관계 설정
필요 시 @ManyToOne(fetch = LAZY) 기본 전략 적용

- 제약 조건 및 속성 정의

엔티티에 created_at, updated_at 공통 컬럼 추가

### 2. 테스트 유저 생성 로직 수정

- 문제 원인
기존에는 동일 이메일로 User를 계속 삽입 → UNIQUE 제약 위반 → DataIntegrityViolationException 발생

- 해결
테스트 유저 자동 삽입 로직 제거 (필요 시 수동 삽입)

### 변경 사항

- User, Post, EmotionTag, PostEmotionTag 엔티티 설계 및 매핑 추가
- 복합키(EmbeddedId)와 연관관계 매핑 적용
- 테스트 유저 중복 삽입 문제 해결