### PR TITLE
feat: 전역 예외 처리 구현 (ErrorCode, CustomException, GlobalExceptionHandler)

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/CustomException.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/CustomException.java
@@ -1,0 +1,15 @@
+package cloud.emusic.emotionmusicapi.exception;
+
+import cloud.emusic.emotionmusicapi.exception.dto.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage()); // RuntimeException에 메시지 전달
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/ErrorResponse.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/ErrorResponse.java
@@ -1,0 +1,22 @@
+package cloud.emusic.emotionmusicapi.exception;
+
+import cloud.emusic.emotionmusicapi.exception.dto.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private int statusCode;
+    private String code;
+    private String message;
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(
+                errorCode.getStatus().value(),
+                errorCode.name(),
+                errorCode.getMessage()
+        );
+    }
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/GlobalExceptionHandler.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package cloud.emusic.emotionmusicapi.exception;
+
+import cloud.emusic.emotionmusicapi.exception.dto.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+// 모든 컨트롤러에서 발생하는 예외를 처리
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 커스텀 예외 처리
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException ex) {
+        log.warn("CustomException 발생: {}", ex.getMessage()); // 디버깅용 로그 확인
+        ErrorCode errorCode = ex.getErrorCode();
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+
+    // 그외 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        log.error("Unexpected exception 발생", ex); // 디버깅용 로그 확인
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+                .status(errorCode.getStatus())
+                .body(ErrorResponse.of(errorCode));
+    }
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
@@ -1,0 +1,21 @@
+package cloud.emusic.emotionmusicapi.exception.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 공통
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다."),
+
+    // 게시글
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
+    POST_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 게시글에 접근할 권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}


### PR DESCRIPTION
## ⚠️ 연관된 이슈
- close #17 

## ✔️ 작업 내용
- **ErrorCode enum 정의**
  - 모든 예외 상황을 공통적으로 적용할 HttpStatus,message 관리
  - 추후 다양한 도메인 예외 상황에 맞는 ErrorCode를 추가하여 사용할 예정입니다
- **CustomException 클래스 정의**
  - 서비스/도메인 계층에서 new CustomException(ErrorCode.xxx) 형태로 예외 처리 가능
- **ErrorResponse DTO 정의**
  - 에러 응답을 JSON으로 반환하기 위한 DTO 입니다
  - statusCode,code,message 포함
- **GlobalExceptionHandler 구현**
  - @RestControllerAdvice 기반 전역 예외 처리기 추가
  - CustomException → 해당 ErrorCode 기반 응답 반환
  - 그 외 예상치 못한 예외는 INTERNAL_SERVER_ERROR 응답
  - 디버깅에 용이하게 로그 확인할 수 있도록 구현