### PR TITLE
fix: spring framework / springdoc 버전 변경 (외 수정사항 없음)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.4'
+	id 'org.springframework.boot' version '3.3.0'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -34,7 +34,7 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation("org.apache.commons:commons-lang3:3.18.0")
 	implementation 'io.github.cdimascio:java-dotenv:5.2.2'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'


### PR DESCRIPTION
⚠️ 연관된 이슈
Closes: #20 

✔️ 작업 내용
Spirng framework / Springdoc 버전 변경

참고사항
의존성충돌이 있어서 버전을 변경한 것이며 현재 개발에 영향은 존재하지 않습니다.
신경쓰지 않고 개발하시면 될 것 같니다.
framework에서 지원하는 doc 버전으로 변경