### PR TITLE
feat: 게시글(Post) 도메인 기능 구현 (등록,조회)

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/config/JwtAuthenticationFilter.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/JwtAuthenticationFilter.java
@@ -1,0 +1,75 @@
+package cloud.emusic.emotionmusicapi.config;
+
+import cloud.emusic.emotionmusicapi.domain.User;
+import cloud.emusic.emotionmusicapi.repository.UserRepository;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final static String HEADER_STRING = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer ";
+
+    // 요청이 들어올 때마다 실행되는 메서드
+    // JWT가 유효하면 인증 객체(SecurityContext)를 설정한다
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        // 1. 요청 헤더에서 JWT 추출
+        String token = resolveToken(request);
+
+        // 2. 토큰이 존재하고 유효하면
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+
+            // 3. 토큰에서 사용자 ID 추출
+            String userId = jwtTokenProvider.getUserId(token);
+            User user = userRepository.findById(Long.parseLong(userId)).orElse(null);
+
+            if (user != null) {
+                // 4. 인증 객체 생성 (권한 포함)
+                UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(user, null,
+                        List.of(new SimpleGrantedAuthority(user.getRole().name())));
+
+                // 5. SecurityContext에 인증 정보 등록
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+
+        // 6. 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        // 1. Authorization 헤더 우선 체크
+        String bearerToken = request.getHeader(HEADER_STRING);
+        if (bearerToken != null && bearerToken.startsWith(TOKEN_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+
+        // 2. access_token 쿠키에서 추출
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("access_token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/config/JwtTokenProvider.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/JwtTokenProvider.java
@@ -6,8 +6,8 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
-import java.security.Key;
 import java.util.Date;
 
 @Component
@@ -19,7 +19,7 @@ public class JwtTokenProvider {
     private static final long JWT_EXPIRATION_TIME = 1000L * 60 * 60 * 24; // 24 hours
 
     // Key 객체로 변환한 서명용 비밀 키
-    private Key key;
+    private SecretKey key;
 
     // 빈 초기화 시점에 Key 객체 생성
     @PostConstruct
@@ -68,10 +68,10 @@ public class JwtTokenProvider {
 
     // Claims 추출 (토큰 내부 정보 파싱)
     private Claims parseClaims(String token) {
-      return Jwts.parserBuilder()
-              .setSigningKey(key)
-              .build()
-              .parseClaimsJws(token)
-              .getBody();
+        return Jwts.parser()                 // parserBuilder() 대신 parser()
+                .verifyWith(key)             // 검증용 키 지정
+                .build()
+                .parseSignedClaims(token)    // parseClaimsJws() → parseSignedClaims()
+                .getPayload();
     }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/config/JwtTokenProvider.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/JwtTokenProvider.java
@@ -1,49 +1,77 @@
 package cloud.emusic.emotionmusicapi.config;
 
-import cloud.emusic.emotionmusicapi.domain.User;
-import io.jsonwebtoken.Header;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.io.Decoders;
+import cloud.emusic.emotionmusicapi.domain.Role;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
 import java.util.Date;
 
 @Component
-@RequiredArgsConstructor
 public class JwtTokenProvider {
 
-  @Value("${JWT_SECRET_KEY}")
-  private String secretKeyString;
+    @Value("${JWT_SECRET_KEY}")
+    private String secretKeyString;
 
-  private SecretKey secretKey;
+    private static final long JWT_EXPIRATION_TIME = 1000L * 60 * 60 * 24; // 24 hours
 
-  private static final long JWT_EXPIRATION_TIME = 1000L * 60 * 60 * 24; // 24 hours
+    // Key 객체로 변환한 서명용 비밀 키
+    private Key key;
 
-  @PostConstruct
-  public void init() {
-    // Use the standard Base64 decoder to match your key format
-    byte[] keyBytes = Decoders.BASE64.decode(secretKeyString);
-    this.secretKey = Keys.hmacShaKeyFor(keyBytes);
-  }
+    // 빈 초기화 시점에 Key 객체 생성
+    @PostConstruct
+    protected void init() {
+      // HMAC-SHA 알고리즘에 맞는 안전한 key 생성
+      key = Keys.hmacShaKeyFor(secretKeyString.getBytes(StandardCharsets.UTF_8));
+    }
 
-  // JWT token generation
-  public String generateToken(User user) {
-    Date now = new Date();
-    Date expiryDate = new Date(now.getTime() + JWT_EXPIRATION_TIME);
+    public String createAccessToken(Long userId, Role role) {
+      return createToken(userId,role,JWT_EXPIRATION_TIME);
+    }
 
-    return Jwts.builder()
-        .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
-        .setIssuer("eMusic")
-        .setIssuedAt(now)
-        .setExpiration(expiryDate)
-//        .setSubject(user.getEmail())
-        .claim("user_id", user.getId())
-        .signWith(secretKey)
-        .compact();
-  }
+    // JWT 토큰 생성 메서드
+    public String createToken(Long userId,Role role, long expiration) {
+
+      Date now = new Date();
+
+      return Jwts.builder()
+              .setSubject(String.valueOf(userId))                                 // 토큰 제목: email (고유 식별자)
+              .claim("role",role.name())                                    // 사용자 역할을 커스텀 클레임으로 추가
+              .setIssuedAt(now)                                                   // 발급 시각
+              .setExpiration(new Date(System.currentTimeMillis() + expiration))   // 만료 시각 설정
+              .signWith(key, SignatureAlgorithm.HS256)                            // 비밀 키로 서명 (HMAC-SHA256)
+              .compact();                                                         // JWT 문자열 생성
+    }
+
+    // 토큰 유효성 검사
+    public boolean validateToken(String token) {
+      try {
+        parseClaims(token);
+        return true;
+      } catch (JwtException | IllegalArgumentException e) {
+        return false;
+      }
+    }
+
+    // 토큰에서 사용자 이메일 추출
+    public String getUserId(String token) {
+      return parseClaims(token).getSubject();
+    }
+
+    // 토큰에서 역할(role) 추출
+    public String getRole(String token) {
+      return parseClaims(token).get("role", String.class);
+    }
+
+    // Claims 추출 (토큰 내부 정보 파싱)
+    private Claims parseClaims(String token) {
+      return Jwts.parserBuilder()
+              .setSigningKey(key)
+              .build()
+              .parseClaimsJws(token)
+              .getBody();
+    }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/config/SwaggerConfig.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/SwaggerConfig.java
@@ -25,9 +25,11 @@ public class SwaggerConfig {
         Components components = new Components()
                 .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
                         .name(jwtSchemeName)
-                        .type(SecurityScheme.Type.HTTP) // HTTP 방식
-                        .scheme("bearer") // bearer 토큰 방식
-                        .bearerFormat("JWT")); // JWT 형식
+                        .type(SecurityScheme.Type.HTTP)   // HTTP 인증 방식
+                        .scheme("bearer")                 // Bearer 인증
+                        .bearerFormat("JWT")              // JWT 포맷
+                        .in(SecurityScheme.In.HEADER));
+
 
         return new OpenAPI()
                 .info(info)

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/LoginController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/LoginController.java
@@ -1,4 +1,5 @@
 package cloud.emusic.emotionmusicapi.controller;
+
 import cloud.emusic.emotionmusicapi.config.JwtTokenProvider;
 import cloud.emusic.emotionmusicapi.domain.User;
 import cloud.emusic.emotionmusicapi.dto.request.LoginRequest;
@@ -55,7 +56,7 @@ public class LoginController {
     User user = userService.processKakaoUser(userResponse);
 
     // 4. Generate JWT Token
-    String accessToken = jwtTokenProvider.generateToken(user);
+    String accessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getRole());
 
     // 5. Return JWT Token in Response
     return LoginResponse.builder()

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
@@ -1,0 +1,48 @@
+package cloud.emusic.emotionmusicapi.controller;
+
+import cloud.emusic.emotionmusicapi.dto.request.EmotionTagResponse;
+import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
+import cloud.emusic.emotionmusicapi.service.PostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/posts")
+@Tag(name = "Post API", description = "게시글 관련 API")
+public class PostController {
+
+    private final PostService postService;
+
+    @Operation(
+            summary = "감정 태그 목록 조회",
+            description = "게시글 작성 시 선택할 수 있는 감정 태그 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "감정 태그 목록 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            array = @ArraySchema(schema = @Schema(implementation = EmotionTagResponse.class))
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @GetMapping("/emotion-tags")
+    public ResponseEntity<List<EmotionTagResponse>> getAllEmotionTag() {
+        return ResponseEntity.ok(postService.EmotionTag());
+    }
+
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/request/EmotionTagResponse.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/request/EmotionTagResponse.java
@@ -1,0 +1,17 @@
+package cloud.emusic.emotionmusicapi.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "감정 태그 응답 DTO")
+public class EmotionTagResponse {
+
+    @Schema(description = "감정 태그 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "감정 태그 이름", example = "행복")
+    private String name;
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
@@ -1,0 +1,20 @@
+package cloud.emusic.emotionmusicapi.service;
+
+import cloud.emusic.emotionmusicapi.dto.request.EmotionTagResponse;
+import cloud.emusic.emotionmusicapi.repository.EmotionTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+    private final EmotionTagRepository emotionTagRepository;
+
+    public List<EmotionTagResponse>EmotionTag() {
+        return emotionTagRepository.findAll().stream()
+                .map(tag -> new EmotionTagResponse(tag.getId(),tag.getName()))
+                .toList();
+    }
+}


### PR DESCRIPTION
## ⚠️ 연관된 이슈
- close #23 

## ✔️ 작업 내용

### 1. JWT 인증 로직 추가

- JwtTokenProvider 로직 추가 및 리팩터링
- AccessToken 생성 (createAccessToken)
- 사용자 ID/Role 클레임 포함
- 토큰 검증 및 Claims 파싱 기능 제공

### 2. JWT 인증 필터 구현

- JWT 토큰을 인증하는 클래스가 없어서 JwtAuthenticationFilter 추가 
- 요청 시 Authorization 헤더 또는 access_token 쿠키에서 JWT 추출
- 토큰 검증 후 사용자 정보 로드 및 SecurityContext 등록

### 3. Spring Security 설정 리팩터링

- SecurityConfig에서 JWT 기반 인증 구조 통합
- 세션을 STATELESS로 설정
- JwtAuthenticationFilter를 UsernamePasswordAuthenticationFilter 앞에 등록
- /posts/** → 인증된 사용자만 접근 가능
- Swagger 관련 경로 → SWAGGER 역할 사용자만 접근 가능
- 나머지 요청은 permitAll
- Swagger 전용 InMemoryUserDetailsService 유지

### 4. Swagger 문서화 개선

- JWT Bearer 인증 스키마 등록 (Authorization 헤더 기반)
- Post API에 Swagger 어노테이션 적용

### 5. 게시글 API 추가

- PostController에 감정 태그 목록 조회 API 구현 (/posts/emotion-tags)
- EmotionTagResponse DTO 반환
- 성공/실패 응답에 대한 Swagger 문서화 (200, 500)

## 📌 변경 이유
- JWT 기반 인증 구조 도입으로 세션리스(stateless) 보안 환경을 구축하기 위함
- Swagger 문서에서 JWT 인증을 직접 테스트할 수 있도록 보강
- 게시글 작성 시 필요한 감정 태그 선택 기능 제공
- (**커스텀유저 방식도 사용해보는거 추천드립니다 시간이 없어서 그대로 유지하고 필요한거 추가 했습니다**)