### PR TITLE
feat: 게시글(post) 관련 API 구현

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
                                 "/v3/api-docs/**"
                         ).hasRole("SWAGGER")
                         // 로그인(JWT 인증)된 사용자만 접근 가능
+                        .anyRequest().permitAll()
                 )
                 .httpBasic(withDefaults());
         return http.build();

--- a/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -35,18 +36,10 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                // CORS 설정 활성화 (corsConfigurationSource()의 설정 사용)
-                .cors(withDefaults())
-
-                // CSRF 보안 비활성화 (JWT는 세션이 없으므로 CSRF 불필요)
+    @Order(1)
+    public SecurityFilterChain swaggerSecurity(HttpSecurity http) throws Exception {
+        http.cors(withDefaults())
                 .csrf(AbstractHttpConfigurer::disable)
-
-                // 세션을 사용하지 않도록 설정 (JWT 기반 인증이라 Stateless)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-                // 요청 URL별 권한 규칙 설정
                 .authorizeHttpRequests(auth -> auth
                         // Swagger 관련 URL은 SWAGGER 역할이 있는 사용자만 접근 가능
                         .requestMatchers(
@@ -55,15 +48,22 @@ public class SecurityConfig {
                                 "/v3/api-docs/**"
                         ).hasRole("SWAGGER")
                         // 로그인(JWT 인증)된 사용자만 접근 가능
+                )
+                .httpBasic(withDefaults());
+        return http.build();
+    }
+
+    @Bean
+    @Order(2)
+    public SecurityFilterChain apiSecurity(HttpSecurity http) throws Exception {
+        http.cors(withDefaults())
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/posts/**").authenticated()
-                        // 그 외 모든 요청은 허용 (permitAll)
                         .anyRequest().permitAll()
                 )
-                // Swagger 접근은 HTTP Basic 인증 사용
-                .httpBasic(withDefaults())
-                // UsernamePasswordAuthenticationFilter 실행 전에 JwtAuthenticationFilter 실행
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
-
         return http.build();
     }
 

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
@@ -1,8 +1,9 @@
 package cloud.emusic.emotionmusicapi.controller;
 
-import cloud.emusic.emotionmusicapi.dto.request.EmotionTagResponse;
+import cloud.emusic.emotionmusicapi.dto.response.EmotionTagResponse;
 import cloud.emusic.emotionmusicapi.dto.request.PostCreateRequest;
-import cloud.emusic.emotionmusicapi.dto.request.PostCreateResponse;
+import cloud.emusic.emotionmusicapi.dto.response.PostCreateResponse;
+import cloud.emusic.emotionmusicapi.dto.response.PostResponseDto;
 import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
 import cloud.emusic.emotionmusicapi.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -67,5 +68,18 @@ public class PostController {
             @Valid @RequestBody PostCreateRequest request,
             @AuthenticationPrincipal(expression = "id") Long userId) {
         return ResponseEntity.status(201).body(postService.createPost(userId, request));
+    }
+
+    @Operation(summary = "게시글 목록 조회", description = "모든 게시글을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            array = @ArraySchema(schema = @Schema(implementation = PostResponseDto.class)))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping
+    public ResponseEntity<List<PostResponseDto>> getAllPosts(@AuthenticationPrincipal(expression = "id") Long userId) {
+        return ResponseEntity.ok(postService.getAllPosts());
     }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
@@ -1,6 +1,8 @@
 package cloud.emusic.emotionmusicapi.controller;
 
 import cloud.emusic.emotionmusicapi.dto.request.EmotionTagResponse;
+import cloud.emusic.emotionmusicapi.dto.request.PostCreateRequest;
+import cloud.emusic.emotionmusicapi.dto.request.PostCreateResponse;
 import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
 import cloud.emusic.emotionmusicapi.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,12 +12,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
@@ -45,4 +47,25 @@ public class PostController {
         return ResponseEntity.ok(postService.EmotionTag());
     }
 
+    @Operation(summary = "게시글 작성", description = "JWT 인증된 사용자가 게시글을 작성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "게시글 작성 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = PostCreateResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            ),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @PostMapping
+    public ResponseEntity<PostCreateResponse> create(
+            @Valid @RequestBody PostCreateRequest request,
+            @AuthenticationPrincipal(expression = "id") Long userId) {
+        return ResponseEntity.status(201).body(postService.createPost(userId, request));
+    }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
@@ -79,7 +79,23 @@ public class PostController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping
-    public ResponseEntity<List<PostResponseDto>> getAllPosts(@AuthenticationPrincipal(expression = "id") Long userId) {
+    public ResponseEntity<List<PostResponseDto>> getAllPosts() {
         return ResponseEntity.ok(postService.getAllPosts());
+    }
+
+    @Operation(summary = "게시글 단건 조회", description = "게시글 ID를 사용하여 특정 게시글을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = PostResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/{postId}")
+    public ResponseEntity<PostResponseDto> getPostById(
+            @PathVariable Long postId) {
+        return ResponseEntity.ok(postService.getPost(postId));
     }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/DayTag.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/DayTag.java
@@ -32,4 +32,11 @@ public class DayTag {
 
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+
+    public static DayTag create(String name,Post post) {
+        DayTag tag = new DayTag();
+        tag.name = name;
+        tag.post = post;
+        return tag;
+    }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/Post.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/Post.java
@@ -28,9 +28,29 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PostEmotionTag> emotionTags = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DayTag> dayTags = new ArrayList<>();
+
+    @Column(name = "song_track_id", nullable = false, length = 100)
+    private String songTrackId;
+
     @CreationTimestamp
     private LocalDateTime createdAt;
 
     @UpdateTimestamp
     private LocalDateTime updatedAt;
+
+    public Post(User user,String trackId) {
+        this.user = user;
+        this.songTrackId = trackId;
+    }
+
+    public void addEmotionTag(PostEmotionTag tag) {
+        this.emotionTags.add(tag);
+    }
+
+    public void addDayTag(DayTag dayTag) {
+        dayTags.add(dayTag);
+    }
+
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/PostEmotionTag.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/PostEmotionTag.java
@@ -26,4 +26,9 @@ public class PostEmotionTag {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "emotion_tag_id", nullable = false)
     private EmotionTag emotionTag;
+
+    public PostEmotionTag(Post post, EmotionTag emotionTag) {
+        this.post = post;
+        this.emotionTag = emotionTag;
+    }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/request/PostCreateRequest.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/request/PostCreateRequest.java
@@ -1,0 +1,25 @@
+package cloud.emusic.emotionmusicapi.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Schema(description = "게시글 작성 요청 DTO")
+public class PostCreateRequest {
+
+    @NotBlank(message = "감정 태그는 최소 1개 이상 선택 해야 합니다.")
+    @Size(max = 3, message = "감정 태그는 최대 3개까지 선택할 수 있습니다.")
+    private List<String> emotionTags;
+
+    @NotBlank(message = "하루 태그는 최소 1개 이상 작성 해야 합니다.")
+    @Size(max = 3, message = "하루 태그는 최대 3개까지 작성 할 수 있습니다.")
+    private List<String> dailyTags;
+
+    @NotBlank(message = "노래 트랙 ID는 필수입니다.")
+    private String songTrackId;
+
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/request/PostCreateResponse.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/request/PostCreateResponse.java
@@ -1,0 +1,13 @@
+package cloud.emusic.emotionmusicapi.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "게시글 생성 응답 DTO")
+public class PostCreateResponse {
+    @Schema(description = "생성된 게시글 ID", example = "1")
+    private Long postId;
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/response/EmotionTagResponse.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/response/EmotionTagResponse.java
@@ -1,4 +1,4 @@
-package cloud.emusic.emotionmusicapi.dto.request;
+package cloud.emusic.emotionmusicapi.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/response/PostCreateResponse.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/response/PostCreateResponse.java
@@ -1,4 +1,4 @@
-package cloud.emusic.emotionmusicapi.dto.request;
+package cloud.emusic.emotionmusicapi.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/response/PostResponseDto.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/response/PostResponseDto.java
@@ -1,0 +1,37 @@
+package cloud.emusic.emotionmusicapi.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostResponseDto {
+    @Schema(description = "게시글 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "감정 태그", example = "[\"행복\", \"슬픔\"]")
+    private List<String> emotionTags;
+
+    @Schema(description = "하루 태그", example = "[\"운동\", \"공부\"]")
+    private List<String> dailyTags;
+
+    @Schema(description = "노래 트랙 ID", example = "12345")
+    private String trackId;
+
+    @Schema(description = "작성자", example = "user123")
+    private String user;
+
+    @Schema(description = "작성일", example = "2025-09-04T12:34:56")
+    private LocalDateTime createdAt;
+
+    @Schema(description = "수정일", example = "2025-09-05T14:56:23")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
@@ -12,9 +12,14 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다."),
 
-    // 게시글
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
     POST_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 게시글에 접근할 권한이 없습니다."),
+
+    // 유저
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    // 감정 태그
+    EMOTION_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "감정 태그를 찾을 수 없습니다."),
 
     // 댓글 (추가된 부분)
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),

--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
@@ -14,8 +14,13 @@ public enum ErrorCode {
 
     // 게시글
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
-    POST_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 게시글에 접근할 권한이 없습니다.");
+    POST_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 게시글에 접근할 권한이 없습니다."),
 
+    // 유저
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+
+    // 감정 태그
+    EMOTION_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "감정 태그를 찾을 수 없습니다.");
     private final HttpStatus status;
     private final String message;
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/repository/EmotionTagRepository.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/repository/EmotionTagRepository.java
@@ -3,5 +3,8 @@ package cloud.emusic.emotionmusicapi.repository;
 import cloud.emusic.emotionmusicapi.domain.EmotionTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface EmotionTagRepository extends JpaRepository<EmotionTag, Long> {
+    Optional<EmotionTag> findByName(String name);
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
@@ -1,9 +1,10 @@
 package cloud.emusic.emotionmusicapi.service;
 
 import cloud.emusic.emotionmusicapi.domain.*;
-import cloud.emusic.emotionmusicapi.dto.request.EmotionTagResponse;
+import cloud.emusic.emotionmusicapi.dto.response.EmotionTagResponse;
 import cloud.emusic.emotionmusicapi.dto.request.PostCreateRequest;
-import cloud.emusic.emotionmusicapi.dto.request.PostCreateResponse;
+import cloud.emusic.emotionmusicapi.dto.response.PostCreateResponse;
+import cloud.emusic.emotionmusicapi.dto.response.PostResponseDto;
 import cloud.emusic.emotionmusicapi.exception.CustomException;
 import cloud.emusic.emotionmusicapi.repository.EmotionTagRepository;
 import cloud.emusic.emotionmusicapi.repository.PostRepository;
@@ -54,5 +55,28 @@ public class PostService {
         postRepository.save(post);
 
         return new PostCreateResponse(post.getId());
+    }
+
+    public List<PostResponseDto> getAllPosts() {
+        return postRepository.findAll().stream()
+                .map(post -> PostResponseDto.builder()
+                        .id(post.getId())
+                        .emotionTags(
+                                post.getEmotionTags().stream()
+                                        .map(et -> et.getEmotionTag().getName())
+                                        .toList()
+                        )
+                        .dailyTags(
+                                post.getDayTags().stream()
+                                        .map(DayTag::getName)
+                                        .toList()
+                        )
+                        .trackId(post.getSongTrackId())
+                        .user(post.getUser().getNickname())
+                        .createdAt(post.getCreatedAt())
+                        .updatedAt(post.getUpdatedAt())
+                        .build()
+                )
+                .toList();
     }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
@@ -13,8 +13,8 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.util.List;
-import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.EMOTION_TAG_NOT_FOUND;
-import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.USER_NOT_FOUND;
+
+import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -59,24 +59,35 @@ public class PostService {
 
     public List<PostResponseDto> getAllPosts() {
         return postRepository.findAll().stream()
-                .map(post -> PostResponseDto.builder()
-                        .id(post.getId())
-                        .emotionTags(
-                                post.getEmotionTags().stream()
-                                        .map(et -> et.getEmotionTag().getName())
-                                        .toList()
-                        )
-                        .dailyTags(
-                                post.getDayTags().stream()
-                                        .map(DayTag::getName)
-                                        .toList()
-                        )
-                        .trackId(post.getSongTrackId())
-                        .user(post.getUser().getNickname())
-                        .createdAt(post.getCreatedAt())
-                        .updatedAt(post.getUpdatedAt())
-                        .build()
+                .map(this::getResponseDto
                 )
                 .toList();
+    }
+
+    public PostResponseDto getPost(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
+
+        return getResponseDto(post);
+    }
+
+    private PostResponseDto getResponseDto(Post post) {
+        return PostResponseDto.builder()
+                .id(post.getId())
+                .emotionTags(
+                        post.getEmotionTags().stream()
+                                .map(et -> et.getEmotionTag().getName())
+                                .toList()
+                )
+                .dailyTags(
+                        post.getDayTags().stream()
+                                .map(DayTag::getName)
+                                .toList()
+                )
+                .trackId(post.getSongTrackId())
+                .user(post.getUser().getNickname())
+                .createdAt(post.getCreatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
@@ -1,20 +1,58 @@
 package cloud.emusic.emotionmusicapi.service;
 
+import cloud.emusic.emotionmusicapi.domain.*;
 import cloud.emusic.emotionmusicapi.dto.request.EmotionTagResponse;
+import cloud.emusic.emotionmusicapi.dto.request.PostCreateRequest;
+import cloud.emusic.emotionmusicapi.dto.request.PostCreateResponse;
+import cloud.emusic.emotionmusicapi.exception.CustomException;
 import cloud.emusic.emotionmusicapi.repository.EmotionTagRepository;
+import cloud.emusic.emotionmusicapi.repository.PostRepository;
+import cloud.emusic.emotionmusicapi.repository.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import java.util.List;
+import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.EMOTION_TAG_NOT_FOUND;
+import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
 
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
     private final EmotionTagRepository emotionTagRepository;
 
     public List<EmotionTagResponse>EmotionTag() {
         return emotionTagRepository.findAll().stream()
                 .map(tag -> new EmotionTagResponse(tag.getId(),tag.getName()))
                 .toList();
+    }
+
+    @Transactional
+    public PostCreateResponse createPost(Long userId, PostCreateRequest request) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        // 2. Post 엔티티 생성
+        Post post = new Post(user,request.getSongTrackId());
+
+        // 3. 감정 태그 매핑 → PostEmotionTag 엔티티 생성
+        request.getEmotionTags().forEach(tagName -> {
+            EmotionTag emotionTag = emotionTagRepository.findByName(tagName)
+                    .orElseThrow(() -> new CustomException(EMOTION_TAG_NOT_FOUND));
+            post.addEmotionTag(new PostEmotionTag(post, emotionTag));
+        });
+
+        // 4. 하루 태그 매핑 → DayTag 엔티티 생성
+        request.getDailyTags().forEach(tagName -> {
+            DayTag dayTag = DayTag.create(tagName,post);
+            post.addDayTag(dayTag);
+        });
+
+        postRepository.save(post);
+
+        return new PostCreateResponse(post.getId());
     }
 }


### PR DESCRIPTION
## ⚠️ 연관된 이슈
close : #27


## ✔️ 작업 내용
- POST /posts : 게시글 생성
- GET /posts/{id} : 게시글 단건 조회
- GET /posts : 게시글 목록 조회 (페이징/정렬 지원)
-  Swagger 전용 Basic Auth와 API 전용 JWT 인증 분리 
   - Swagger 관련 엔드포인트는 별도 SecurityFilterChain(@order(1))으로 분리
   - SWAGGER 계정 기반 Basic Auth 인증 적용
- 일반 API 엔드포인트는 SecurityFilterChain(@order(2))으로 관리
  - /posts/** 요청은 JWT 인증 필수
  - 나머지 엔드포인트는 permitAll 처리
- 일단 등록,조회만 구현하고 나머지 도메인도 작업해야 할것같습니다