### PR TITLE
fix: Swagger 전용 SecurityFilterChain에서 불필요한 permitAll 제거

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
@@ -48,7 +48,6 @@ public class SecurityConfig {
                                 "/v3/api-docs/**"
                         ).hasRole("SWAGGER")
                         // 로그인(JWT 인증)된 사용자만 접근 가능
-                        .anyRequest().permitAll()
                 )
                 .httpBasic(withDefaults());
         return http.build();


### PR DESCRIPTION
## ⚠️ 연관된 이슈
close : #33


## ✔️ 작업 내용
- swaggerSecurity에 있던 `.anyRequest().permitAll()` 삭제
- Swagger URL 이외의 요청이 잘못 허용되던 문제 해결