### PR TITLE
fix: SecurityFilterChain URL 매칭 오류 수정

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
     @Order(1)
     public SecurityFilterChain swaggerSecurity(HttpSecurity http) throws Exception {
         http.cors(withDefaults())
+                .securityMatcher("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**")
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         // Swagger 관련 URL은 SWAGGER 역할이 있는 사용자만 접근 가능
@@ -57,10 +58,12 @@ public class SecurityConfig {
     @Order(2)
     public SecurityFilterChain apiSecurity(HttpSecurity http) throws Exception {
         http.cors(withDefaults())
+                .securityMatcher("/**")
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/posts/**").authenticated()
+                        .requestMatchers("/login/url","login/authenticate").permitAll()
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## ⚠️ 연관된 이슈
close : #33


## ✔️ 작업 내용
- swaggerSecurity에 securityMatcher 추가하여 Swagger URL만 매칭되도록 제한
- apiSecurity에 securityMatcher("/**") 적용하여 나머지 요청 처리
- /login/** 엔드포인트는 permitAll로 열어 JWT 발급 가능
- /posts/** 엔드포인트는 JWT 인증 필수로 유지