### PR TITLE
feat: 로그인 유저가 작성한 게시글 목록 조회 API 구현

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
@@ -138,4 +138,21 @@ public class PostController {
         postService.deletePost(postId, userId);
         return ResponseEntity.noContent().build();
     }
+
+    @Operation(summary = "감정 캘린더 조회", description = "로그인한 사용자가 작성한 게시글을 날짜별로 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = PostResponseDto.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/calendar")
+    public ResponseEntity<List<PostResponseDto>> getMyEmotionCalendar(
+            @AuthenticationPrincipal(expression = "id") Long userId
+    ) {
+        return ResponseEntity.ok(postService.getPostCalendar(userId));
+    }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/repository/PostRepository.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/repository/PostRepository.java
@@ -1,7 +1,12 @@
 package cloud.emusic.emotionmusicapi.repository;
 
 import cloud.emusic.emotionmusicapi.domain.Post;
+import cloud.emusic.emotionmusicapi.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    List<Post> findAllByUser(User user);
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
@@ -155,4 +155,18 @@ public class PostService {
 
         postRepository.delete(post);
     }
+
+    public List<PostResponseDto> getPostCalendar(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        return postRepository.findAllByUser(user).stream()
+                .map(post -> {
+                    long likeCount = likeRepository.countByPost(post);
+                    long commentCount = commentRepository.countByPost(post);
+                    boolean isLiked = likeRepository.existsByPostAndUser(post,post.getUser());
+                    return PostResponseDto.from(post,likeCount,isLiked,commentCount);
+                })
+                .toList();
+    }
 }


### PR DESCRIPTION
## 💡 개요
- 감정 캘린더에 필요한 API 구현

## 🔨 작업 내용
- 로그인 유저가 작성한 게시물만 조회하는 API 구현

## 🔗 관련 이슈
closes  #45 