### PR TITLE
fix: isLiked 로직 수정 및 DTO 변환 메서드 분리

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
@@ -79,8 +79,8 @@ public class PostController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping
-    public ResponseEntity<List<PostResponseDto>> getAllPosts() {
-        return ResponseEntity.ok(postService.getAllPosts());
+    public ResponseEntity<List<PostResponseDto>> getAllPosts(@AuthenticationPrincipal(expression = "id") Long userId) {
+        return ResponseEntity.ok(postService.getAllPosts(userId));
     }
 
     @Operation(summary = "게시글 단건 조회", description = "게시글 ID를 사용하여 특정 게시글을 조회합니다.")
@@ -95,8 +95,9 @@ public class PostController {
     })
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponseDto> getPostById(
-            @PathVariable Long postId) {
-        return ResponseEntity.ok(postService.getPost(postId));
+            @PathVariable Long postId,
+            @AuthenticationPrincipal(expression = "id") Long userId){
+        return ResponseEntity.ok(postService.getPost(postId,userId));
     }
 
     @Operation(summary = "게시글 수정", description = "게시글 ID를 사용하여 특정 게시글을 수정합니다.")


### PR DESCRIPTION
## 💡 개요
- 게시글 작성자 기준으로 처리되던 isLiked 로직을 로그인 사용자 기준으로 수정
- 게시글 → PostResponseDto 변환 과정을 buildPostResponseDto() 메서드로 분리
- 중복 코드 제거 및 가독성, 유지보수성 향상

## 🔗 관련 이슈
closes #51
