### PR TITLE
feat: 게시글 목록 조회 정렬 기능 추가

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
@@ -7,6 +7,7 @@ import cloud.emusic.emotionmusicapi.dto.response.PostResponseDto;
 import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
 import cloud.emusic.emotionmusicapi.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -79,8 +80,20 @@ public class PostController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping
-    public ResponseEntity<List<PostResponseDto>> getAllPosts(@AuthenticationPrincipal(expression = "id") Long userId) {
-        return ResponseEntity.ok(postService.getAllPosts(userId));
+    public ResponseEntity<List<PostResponseDto>> getAllPosts(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @Parameter(description = "정렬 기준 (예: createdAt, likeCount)")
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+
+            @Parameter(description = "정렬 방식 (asc 또는 desc)")
+            @RequestParam(defaultValue = "desc") String direction,
+
+            @Parameter(description = "조회할 페이지 번호 (0부터 시작)")
+            @RequestParam(defaultValue = "0") int page,
+
+            @Parameter(description = "조회할 페이지 크기")
+            @RequestParam(defaultValue = "10") int size) {
+        return ResponseEntity.ok(postService.getAllPosts(userId,sortBy,direction,page,size));
     }
 
     @Operation(summary = "게시글 단건 조회", description = "게시글 ID를 사용하여 특정 게시글을 조회합니다.")

--- a/src/main/java/cloud/emusic/emotionmusicapi/repository/PostRepository.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/repository/PostRepository.java
@@ -3,10 +3,22 @@ package cloud.emusic.emotionmusicapi.repository;
 import cloud.emusic.emotionmusicapi.domain.Post;
 import cloud.emusic.emotionmusicapi.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByUser(User user);
+
+    @Query(value = """
+    SELECT p.*, COUNT(pl.post_id) AS like_count
+    FROM post p
+    LEFT JOIN post_like pl ON p.post_id = pl.post_id
+    GROUP BY p.post_id
+    ORDER BY like_count DESC
+    LIMIT :limit OFFSET :offset
+""", nativeQuery = true)
+    List<Object[]> findPostsOrderByLikeCount(@Param("limit") int limit, @Param("offset") int offset);
 }


### PR DESCRIPTION
## 💡 개요
- GET /posts API에 정렬 파라미터(sortBy, direction) 추가
- sortBy=likeCount일 경우 좋아요 수 기준 정렬 처리
- Swagger 문서에 정렬 옵션 설명 추가

## 🔗 관련 이슈
close #53 
