### PR TITLE
feat: 실시간 태그 검색 순위 조회 API 구현

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
@@ -62,8 +62,8 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/login/url","login/authenticate","/posts/emotion-tags").permitAll()
-                        .requestMatchers("/posts/**").authenticated()
+                        .requestMatchers("/login/url","/login/authenticate","/posts/emotion-tags","/tags/**").permitAll()
+                        .requestMatchers("/posts/**","/users/me").authenticated()
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/TagController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/TagController.java
@@ -1,0 +1,46 @@
+package cloud.emusic.emotionmusicapi.controller;
+
+import cloud.emusic.emotionmusicapi.dto.response.TagRankingResponseWrapper;
+import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
+import cloud.emusic.emotionmusicapi.service.TagService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/tags")
+@Tag(name = "Tag API", description = "태그 관련 API 문서입니다.")
+public class TagController {
+
+    private final TagService tagService;
+
+    @Operation(
+            summary = "실시간 태그 검색 랭킹 조회",
+            description = "실시간 태그 검색 랭킹을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "태그 랭킹 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = TagRankingResponseWrapper.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
+            )
+    })
+    @GetMapping("/ranking")
+    public ResponseEntity<TagRankingResponseWrapper> getAllTagRankings() {
+        return ResponseEntity.ok(tagService.getTagRankings());
+    }
+
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/response/TagRankingResponse.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/response/TagRankingResponse.java
@@ -1,0 +1,18 @@
+package cloud.emusic.emotionmusicapi.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Schema(description = "태그 랭킹 응답 DTO")
+public class TagRankingResponse {
+
+    @Schema(description = "태그 이름", example = "tag1")
+    private String tagName;
+
+    @Schema(description = "태그 사용 횟수", example = "150")
+    private Long tagCount;
+
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/response/TagRankingResponseWrapper.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/response/TagRankingResponseWrapper.java
@@ -1,0 +1,19 @@
+package cloud.emusic.emotionmusicapi.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Schema(description = "태그 랭킹 응답 전체 구조")
+public class TagRankingResponseWrapper {
+
+    @Schema(description = "게시글 태그 랭킹 리스트")
+    private List<TagRankingResponse> emotionTags;
+
+    @Schema(description = "하루 태그 랭킹 리스트")
+    private List<TagRankingResponse> dayTags;
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/repository/DayTagRepository.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/repository/DayTagRepository.java
@@ -1,7 +1,19 @@
 package cloud.emusic.emotionmusicapi.repository;
 
 import cloud.emusic.emotionmusicapi.domain.DayTag;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface DayTagRepository extends JpaRepository<DayTag, Long> {
+
+    @Query("""
+    SELECT dt.name, COUNT(dt.post.id)
+    FROM DayTag dt
+    GROUP BY dt.name
+    ORDER BY COUNT(dt.post.id) DESC
+""")
+    List<Object[]> findTopDayTags(Pageable pageable);
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/repository/PostEmotionTagRepository.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/repository/PostEmotionTagRepository.java
@@ -1,7 +1,20 @@
 package cloud.emusic.emotionmusicapi.repository;
 
 import cloud.emusic.emotionmusicapi.domain.PostEmotionTag;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface PostEmotionTagRepository extends JpaRepository<PostEmotionTag, Long> {
+
+    @Query("""
+    SELECT et.name, COUNT(pet.post.id)
+    FROM PostEmotionTag pet
+    JOIN pet.emotionTag et
+    GROUP BY et.name
+    ORDER BY COUNT(pet.post.id) DESC
+""")
+    List<Object[]> findTopEmotionTags(Pageable pageable);
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/TagService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/TagService.java
@@ -1,0 +1,35 @@
+package cloud.emusic.emotionmusicapi.service;
+
+import cloud.emusic.emotionmusicapi.dto.response.TagRankingResponse;
+import cloud.emusic.emotionmusicapi.dto.response.TagRankingResponseWrapper;
+import cloud.emusic.emotionmusicapi.repository.DayTagRepository;
+import cloud.emusic.emotionmusicapi.repository.PostEmotionTagRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+
+    private final PostEmotionTagRepository postEmotionTagRepository;
+    private final DayTagRepository dayTagRepository;
+
+    public TagRankingResponseWrapper getTagRankings() {
+
+        List<TagRankingResponse> postEmotionTagRankings = postEmotionTagRepository
+                .findTopEmotionTags(PageRequest.of(0,10)).stream()
+                .map(row -> new TagRankingResponse((String) row[0], (long) ((Number) row[1]).intValue())).toList();
+
+        List<TagRankingResponse> dayTagRankings = dayTagRepository
+                .findTopDayTags(PageRequest.of(0,10)).stream()
+                .map(row -> new TagRankingResponse((String) row[0], (long) ((Number) row[1]).intValue())).toList();
+
+        TagRankingResponseWrapper wrapper = new TagRankingResponseWrapper();
+        wrapper.setEmotionTags(postEmotionTagRankings);
+        wrapper.setDayTags(dayTagRankings);
+
+        return wrapper;
+    }
+}


### PR DESCRIPTION
## 💡 개요
- 실시간 태그 검색 랭킹 조회 API 추가
- 게시글 태그(postTags)와 하루 태그(dayTags)Top 10 랭킹 조회
- DTO(`TagRankingResponse`, `TagRankingResponseWrapper`)를 사용하여 Swagger 문서화 개선
- `/Ranking` 엔드포인트로 호출 가능
- Security 접근 제어 규칙 엔드포인트 수정

## 🔗 관련 이슈
closes #55