### PR TITLE
feat: 감정 기반 노래 추천 기능 API 구현

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -63,6 +63,8 @@ jobs:
             KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}
             KAKAO_CLIENT_SECRET=${{ secrets.KAKAO_CLIENT_SECRET }}
             JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
+            SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
+            SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
 
             EOF
             

--- a/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/login/url","/login/authenticate","/posts/emotion-tags","/tags/**").permitAll()
+                        .requestMatchers("/login/url","/login/authenticate","/posts/emotion-tags","/tags/**","/songs/**").permitAll()
                         .requestMatchers("/posts/**","/users/me").authenticated()
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/SpotifyController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/SpotifyController.java
@@ -1,0 +1,61 @@
+package cloud.emusic.emotionmusicapi.controller;
+
+import cloud.emusic.emotionmusicapi.dto.response.TrackResponse;
+import cloud.emusic.emotionmusicapi.service.SpotifyService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/songs")
+@RequiredArgsConstructor
+public class SpotifyController {
+
+    private final SpotifyService spotifyService;
+
+    @Operation(
+            summary = "감정 기반 노래 추천",
+            description = "사용자가 선택한 감정 태그(최대 3개)를 기반으로 최신 K-pop 곡을 추천합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "추천 곡 목록 반환 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            array = @ArraySchema(schema = @Schema(implementation = TrackResponse.class))
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping("/recommend")
+    public ResponseEntity<List<TrackResponse>> recommend(
+            @Parameter(
+                    description = "감정 태그 목록 (최대 3개). 예: emotions=슬픔,외로움,피곤함",
+                    example = "슬픔,외로움,피곤함"
+            )
+            @RequestParam List<String> emotions,
+
+            @Parameter(
+                    description = "추천 곡 개수 (기본값 10)",
+                    example = "10"
+            )
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        return ResponseEntity.ok(spotifyService.recommendByEmotions(emotions, limit));
+    }
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/request/EmotionMapper.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/request/EmotionMapper.java
@@ -1,0 +1,33 @@
+package cloud.emusic.emotionmusicapi.dto.request;
+
+import java.util.List;
+import java.util.Map;
+
+public class EmotionMapper {
+    private static final Map<String, List<String>> emotionGenres = Map.ofEntries(
+            Map.entry("기쁨", List.of("k-pop", "dance", "idol")),
+            Map.entry("행복", List.of("k-pop", "dance")),
+            Map.entry("즐거움", List.of("k-pop", "dance")),
+            Map.entry("설렘", List.of("k-pop", "j-pop", "idol")),
+            Map.entry("두근거림", List.of("k-pop", "dance")),
+            Map.entry("놀람", List.of("k-pop", "dance")),
+            Map.entry("감동", List.of("ballad", "acoustic", "k-indie")),
+            Map.entry("화남", List.of("k-hip-hop", "rock")),
+            Map.entry("짜증", List.of("k-hip-hop", "rock")),
+            Map.entry("슬픔", List.of("ballad", "acoustic")),
+            Map.entry("우울", List.of("ballad", "acoustic")),
+            Map.entry("외로움", List.of("ballad", "acoustic")),
+            Map.entry("피곤함", List.of("lo-fi", "chill", "k-indie")),
+            Map.entry("졸림", List.of("lo-fi", "chill")),
+            Map.entry("힘듦", List.of("acoustic", "lo-fi")),
+            Map.entry("복잡함", List.of("indie", "alternative", "k-indie")),
+            Map.entry("어지러운", List.of("indie", "alternative"))
+    );
+
+    public static List<String> getGenres(List<String> emotions) {
+        return emotions.stream()
+                .flatMap(e -> emotionGenres.getOrDefault(e, List.of("pop")).stream())
+                .distinct()
+                .toList();
+    }
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/response/TrackResponse.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/response/TrackResponse.java
@@ -1,0 +1,18 @@
+package cloud.emusic.emotionmusicapi.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TrackResponse {
+    private String id;
+    private String name;
+    private String artist;
+    private String spotifyUrl;
+    private String imageUrl;
+    private double valence;
+    private double energy;
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/SpotifyService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/SpotifyService.java
@@ -26,10 +26,10 @@ public class SpotifyService {
     private final RestTemplate restTemplate = new RestTemplate();
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    @Value("${spotify.client-id}")
+    @Value("${SPOTIFY_CLIENT_ID}")
     private String clientId;
 
-    @Value("${spotify.client-secret}")
+    @Value("${SPOTIFY_CLIENT_SECRET}")
     private String clientSecret;
 
     public List<TrackResponse> recommendByEmotions(List<String> emotions, int limit) {

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/SpotifyService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/SpotifyService.java
@@ -1,0 +1,124 @@
+package cloud.emusic.emotionmusicapi.service;
+
+import cloud.emusic.emotionmusicapi.dto.request.EmotionMapper;
+import cloud.emusic.emotionmusicapi.dto.response.TrackResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SpotifyService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${spotify.client-id}")
+    private String clientId;
+
+    @Value("${spotify.client-secret}")
+    private String clientSecret;
+
+    public List<TrackResponse> recommendByEmotions(List<String> emotions, int limit) {
+        String accessToken = getAccessToken();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        // 1. 감정 → 장르 매핑
+        List<String> genres = EmotionMapper.getGenres(emotions);
+        String query = genres.stream()
+                .map(g -> "genre:" + g)
+                .collect(Collectors.joining(" OR "));
+        query = "korean " + query + " year:2015-2025"; // 한국어 + 최신곡 조건
+
+        List<TrackResponse> allResults = new ArrayList<>();
+
+        // 2. 최대 200곡 가져오기 (50 * 4)
+        for (int offset = 0; offset < 200; offset += 50) {
+            String searchUrl = String.format(
+                    "https://api.spotify.com/v1/search?q=%s&type=track&limit=50&offset=%d&market=KR",
+                    URLEncoder.encode(query, StandardCharsets.UTF_8),
+                    offset
+            );
+
+            ResponseEntity<String> searchResponse = restTemplate.exchange(
+                    searchUrl, HttpMethod.GET, entity, String.class
+            );
+
+            try {
+                JsonNode items = objectMapper.readTree(searchResponse.getBody())
+                        .path("tracks").path("items");
+
+                items.forEach(item -> {
+                    String name = item.get("name").asText();
+                    String releaseDate = item.path("album").path("release_date").asText();
+
+                    // 3. 필터링: 한국어/숫자 제목 + 발매일 조건
+                    if (!name.matches(".*[가-힣0-9].*")) return;
+                    if (releaseDate.compareTo("2015-01-01") < 0) return;
+
+                    String imageUrl = null;
+                    JsonNode images = item.path("album").path("images");
+                    if (images.isArray() && images.size() > 0) {
+                        imageUrl = images.get(0).get("url").asText();
+                    }
+
+                    allResults.add(new TrackResponse(
+                            item.get("id").asText(),
+                            name,
+                            item.path("artists").get(0).get("name").asText(),
+                            item.path("external_urls").get("spotify").asText(),
+                            imageUrl,
+                            0.0, 0.0
+                    ));
+                });
+            } catch (Exception e) {
+                throw new RuntimeException("Search API 파싱 실패", e);
+            }
+        }
+
+        // 4. 최종 결과: 요청한 개수만큼 반환
+        return allResults.stream()
+                .limit(limit)
+                .collect(Collectors.toList());
+    }
+
+
+    private String getAccessToken() {
+        String url = "https://accounts.spotify.com/api/token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setBasicAuth(clientId, clientSecret); // client_id:client_secret → Base64 자동 인코딩
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "client_credentials");
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                request,
+                Map.class
+        );
+
+        return (String) response.getBody().get("access_token");
+    }
+}


### PR DESCRIPTION
## 💡 개요
- 감정 태그 기반 노래 추천 API 구현

사용자 감정(최대 3개) → 장르 매핑 → Spotify Search API 호출
한국어/숫자 제목 필터링 적용
발매일(2015년 이후) 조건 반영

- Spotify API 환경 변수 관리 개선

application.yml에서 SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET 환경 변수 참조하도록 수정
SpotifyAuthService의 @Value 주입 값 변경
GitHub Actions Secrets 기반 관리 가능

## 🔗 관련 이슈
closes #57 
