### PR TITLE
feat: 태그별 노래 랭킹 조회 API 구현

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/TagController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/TagController.java
@@ -1,5 +1,6 @@
 package cloud.emusic.emotionmusicapi.controller;
 
+import cloud.emusic.emotionmusicapi.dto.response.EmotionTrackGroupResponse;
 import cloud.emusic.emotionmusicapi.dto.response.TagRankingResponseWrapper;
 import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
 import cloud.emusic.emotionmusicapi.service.TagService;
@@ -15,6 +16,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -41,6 +44,20 @@ public class TagController {
     @GetMapping("/ranking")
     public ResponseEntity<TagRankingResponseWrapper> getAllTagRankings() {
         return ResponseEntity.ok(tagService.getTagRankings());
+    }
+
+    @Operation(summary = "태그별 노래 랭크 조회",
+            description = "감정 태그별로 사용된 노래들을 사용 횟수 순으로 정렬하여 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = EmotionTrackGroupResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/song-rank")
+    public ResponseEntity<List<EmotionTrackGroupResponse>> getTracksByEmotion() {
+        return ResponseEntity.ok(tagService.getTracksByEmotion());
     }
 
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/response/EmotionTrackGroupResponse.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/response/EmotionTrackGroupResponse.java
@@ -1,0 +1,23 @@
+package cloud.emusic.emotionmusicapi.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "감정 태그별 노래 사용 통계 응답 DTO")
+public class EmotionTrackGroupResponse {
+
+    @Schema(description = "감정 태그", example = "happy")
+    private String emotionTag;
+
+    @Schema(description = "해당 감정 태그로 사용된 노래의 총 개수", example = "150")
+    private long totalSongCount;
+
+    @Schema(description = "해당 감정 태그로 사용된 노래 목록")
+    private List<TrackUsageResponse> tracks;
+
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/response/TrackUsageResponse.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/response/TrackUsageResponse.java
@@ -1,0 +1,32 @@
+package cloud.emusic.emotionmusicapi.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "노래 사용 통계 응답 DTO")
+public class TrackUsageResponse {
+
+    @Schema(description = "노래 트랙 ID", example = "3n3Ppam7vgaVa1iaRUc9Lp")
+    private String trackId;
+
+    @Schema(description = "노래 제목", example = "Mr. Brightside")
+    private String trackTitle;
+
+    @Schema(description = "노래 아티스트", example = "The Killers")
+    private String artist;
+
+    @Schema(description = "노래 앨범", example = "url")
+    private String albumImageUrl;
+
+    @Schema(description = "노래 사용 횟수", example = "42")
+    private long usageCount;
+
+    @Schema(description = "노래 재생 횟수", example = "10")
+    private long playCount;
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/repository/PostRepository.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/repository/PostRepository.java
@@ -21,4 +21,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     LIMIT :limit OFFSET :offset
 """, nativeQuery = true)
     List<Object[]> findPostsOrderByLikeCount(@Param("limit") int limit, @Param("offset") int offset);
+
+    @Query("SELECT DISTINCT p FROM Post p " +
+            "JOIN FETCH p.song " +
+            "JOIN FETCH p.emotionTags et " +
+            "JOIN FETCH et.emotionTag")
+    List<Post> findAllWithTrackAndTags();
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/TagService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/TagService.java
@@ -1,13 +1,21 @@
 package cloud.emusic.emotionmusicapi.service;
 
+import cloud.emusic.emotionmusicapi.domain.Post;
+import cloud.emusic.emotionmusicapi.domain.Song;
+import cloud.emusic.emotionmusicapi.dto.response.EmotionTrackGroupResponse;
 import cloud.emusic.emotionmusicapi.dto.response.TagRankingResponse;
 import cloud.emusic.emotionmusicapi.dto.response.TagRankingResponseWrapper;
+import cloud.emusic.emotionmusicapi.dto.response.TrackUsageResponse;
 import cloud.emusic.emotionmusicapi.repository.DayTagRepository;
 import cloud.emusic.emotionmusicapi.repository.PostEmotionTagRepository;
+import cloud.emusic.emotionmusicapi.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +23,7 @@ public class TagService {
 
     private final PostEmotionTagRepository postEmotionTagRepository;
     private final DayTagRepository dayTagRepository;
+    private final PostRepository postRepository;
 
     public TagRankingResponseWrapper getTagRankings() {
 
@@ -31,5 +40,40 @@ public class TagService {
         wrapper.setDayTags(dayTagRankings);
 
         return wrapper;
+    }
+
+    public List<EmotionTrackGroupResponse> getTracksByEmotion() {
+        List<Post> posts = postRepository.findAllWithTrackAndTags();
+
+        // 감정 태그별 (곡 → count) 그룹화
+        Map<String, Map<Song, Long>> grouped = posts.stream()
+                .flatMap(post -> post.getEmotionTags().stream()
+                        .map(tag -> Map.entry(tag.getEmotionTag().getName(), post.getSong())))
+                .collect(Collectors.groupingBy(
+                        e -> e.getKey(),
+                        Collectors.groupingBy(e -> e.getValue(), Collectors.counting())
+                ));
+
+        // count 기준 정렬 후 DTO 변환
+        return grouped.entrySet().stream()
+                .map(entry -> {
+                    String tagName = entry.getKey();
+                    List<TrackUsageResponse> sortedTracks = entry.getValue().entrySet().stream()
+                            .sorted(Map.Entry.<Song, Long>comparingByValue().reversed())
+                            .map(e -> {
+                                Song song = e.getKey();
+                                return new TrackUsageResponse(
+                                        song.getTrackId(),
+                                        song.getTitle(),
+                                        song.getArtist(),
+                                        song.getAlbumArtUrl(),
+                                        e.getValue(),
+                                        song.getPlayCount()
+                                );
+                            })
+                            .toList();
+                    return new EmotionTrackGroupResponse(tagName,sortedTracks.size(),sortedTracks);
+                })
+                .toList();
     }
 }


### PR DESCRIPTION
## 💡 개요
- DTO 추가 (TrackUsageResponse, EmotionTrackGroupResponse)
- Service: 감정 태그별 곡 사용 횟수 집계 및 내림차순 정렬

## 🔗 관련 이슈
close #65 