### PR TITLE
fix: 좋아요한 게시글 조회 기능중 다른 사람의 게시글의 좋아요 여부 false로 나오는 버그 해결

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/repository/LikeRepository.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/repository/LikeRepository.java
@@ -16,7 +16,7 @@ public interface LikeRepository extends JpaRepository<PostLike, Long> {
 
     List<PostLike> findAllByUser(User user);
 
-    boolean existsByPostAndUser(Post post, User user);
+    boolean existsByPostIdAndUserId(Long postId, Long userId);
 
     void deleteByPost(Post post);
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/LikeService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/LikeService.java
@@ -67,7 +67,7 @@ public class LikeService {
                             Post post = like.getPost();
                             long likeCount = likeRepository.countByPost(post);
                             long commentCount = commentRepository.countByPost(post);
-                            boolean isLiked = likeRepository.existsByPostAndUser(post,post.getUser());
+                            boolean isLiked = likeRepository.existsByPostIdAndUserId(post.getId(), userId);
                             return PostResponseDto.from(post,likeCount,isLiked,commentCount);
                         })
                 .collect(Collectors.toList());

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
@@ -92,7 +92,7 @@ public class PostService {
 
                     Long likeCount = ((Number) result[result.length - 1]).longValue();
                     Long commentCount = commentRepository.countByPost(post);
-                    boolean isLiked = likeRepository.existsByPostAndUser(post, user);
+                    boolean isLiked = likeRepository.existsByPostIdAndUserId(post.getId(), user.getId());
 
                     return PostResponseDto.from(post, likeCount, isLiked, commentCount);
                 }).toList();
@@ -102,7 +102,7 @@ public class PostService {
                 .map(post -> {
                     long likeCount = likeRepository.countByPost(post);
                     long commentCount = commentRepository.countByPost(post);
-                    boolean isLiked = likeRepository.existsByPostAndUser(post, user);
+                    boolean isLiked = likeRepository.existsByPostIdAndUserId(post.getId(), user.getId());
                     return PostResponseDto.from(post, likeCount, isLiked, commentCount);
                 })
                 .toList();
@@ -180,7 +180,7 @@ public class PostService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        boolean isLiked = likeRepository.existsByPostAndUser(post, user);
+        boolean isLiked = likeRepository.existsByPostIdAndUserId(post.getId(), user.getId());
 
         return PostResponseDto.from(post, likeCount, isLiked, commentCount);
     }
@@ -212,7 +212,7 @@ public class PostService {
     private PostResponseDto getPostResponse(Post post, User user) {
         long likeCount = likeRepository.countByPost(post);
         long commentCount = commentRepository.countByPost(post);
-        boolean isLiked = likeRepository.existsByPostAndUser(post, user);
+        boolean isLiked = likeRepository.existsByPostIdAndUserId(post.getId(), user.getId());
         return PostResponseDto.from(post, likeCount, isLiked, commentCount);
     }
 }


### PR DESCRIPTION
## 💡 개요
- Post,User 엔티티의 ID값으로 체크 하여 정확한 게시글 좋아요 여부 체크 하도록 변경

## 🔗 관련 이슈
close #67 
