### PR TITLE
refactor: 로그인 유저 날짜별 게시글 단건 조회 응답 방식 수정

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
 
 @RestController
 @RequiredArgsConstructor
@@ -184,10 +185,11 @@ public class PostController {
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
     @GetMapping("/me")
-    public ResponseEntity<PostResponseDto> getMyPost(
+    public ResponseEntity<Object> getMyPost(
             @AuthenticationPrincipal(expression = "id") Long userId,
             @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate createdDate
     ) {
-        return ResponseEntity.ok(postService.getMyPost(userId,createdDate));
+        PostResponseDto response = postService.getMyPost(userId, createdDate);
+        return ResponseEntity.ok(Objects.requireNonNullElse(response, "null"));
     }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/repository/PostRepository.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/repository/PostRepository.java
@@ -5,17 +5,16 @@ import cloud.emusic.emotionmusicapi.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByUser(User user);
 
     @Query("SELECT p FROM Post p WHERE p.user = :user AND p.createdAt >= :start AND p.createdAt < :end")
-    Post findByUserAndCreatedDate(
+    Optional<Post> findByUserAndCreatedDate(
             @Param("user") User user,
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
@@ -219,7 +219,9 @@ public class PostService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        return getPostResponse(postRepository.findByUserAndCreatedDate(user,start,end),user);
+        Post post = postRepository.findByUserAndCreatedDate(user,start,end).orElse(null);
+
+        return post != null ? getPostResponse(post, user) : null;
     }
 
     private PostResponseDto getPostResponse(Post post, User user) {


### PR DESCRIPTION
## 💡 개요
- 기존 방식은 해당 날짜에 작성된 게시글이 없다면 500번 에러를 보내는 구조로 되어 있음

## 🔨 작업 내용
- 프론트의 요청으로 해당 날짜에 작성된 게시글이 없다면 "null"로 반환 하도록 변경

## 🔗 관련 이슈
close #79 