### PR TITLE
feat: JWT 토큰 유효시간 단축 및 차단 유저 처리

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/jwt/JwtTokenProvider.java
@@ -16,7 +16,7 @@ public class JwtTokenProvider {
     @Value("${JWT_SECRET_KEY}")
     private String secretKeyString;
 
-    private static final long JWT_EXPIRATION_TIME = 1000L * 60 * 60 * 24; // 24 hours
+    private static final long JWT_EXPIRATION_TIME = 1000L * 60 * 60; // 1시간
 
     // Key 객체로 변환한 서명용 비밀 키
     private SecretKey key;

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/user/User.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/user/User.java
@@ -39,6 +39,10 @@ public class User {
     @Column(name = "role", nullable = false)
     private Role role;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private UserStatus status = UserStatus.ACTIVE;
+
     @Column(name = "profile_image", nullable = false)
     private String profileImage;
 

--- a/src/main/java/cloud/emusic/emotionmusicapi/domain/user/UserStatus.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/domain/user/UserStatus.java
@@ -1,0 +1,6 @@
+package cloud.emusic.emotionmusicapi.domain.user;
+
+public enum UserStatus {
+    ACTIVE,
+    BLOCKED
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 
     // 유저
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    USER_BLOCKED(HttpStatus.FORBIDDEN, "차단된 사용자입니다."),
 
     // 감정 태그
     EMOTION_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "감정 태그를 찾을 수 없습니다."),


### PR DESCRIPTION
## 💡 개요
- 기존의 JWT 토큰 유효시간이 너무 긴 보안적 이슈
- 유저의 악의적인 공격을 차단 하기 위한 차단 유저 관리가 필요함

## 🔨 작업 내용
- JWT 토큰의 유효시간을 24시간에서 1시간으로 축소
- User 테이블에 차단 상태를 추가하여 JWT 토큰 발급 로직에서 확인후 발급
- 차단된 유저는 JWT 토큰이 발급되지 않음

## 🔗 관련 이슈
close #90
