### PR TITLE
feat: 각 게시글 하루에 작성할 수 있는 댓글 갯수 5개 제한

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     // 댓글 (추가된 부분)
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 댓글에 접근할 권한이 없습니다."),
+    COMMENT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "하루에 작성할 수 있는 댓글 수를 초과했습니다."),
 
     // 좋아요
     ALREADY_LIKED(HttpStatus.BAD_REQUEST, "이미 좋아요를 눌렀습니다."),

--- a/src/main/java/cloud/emusic/emotionmusicapi/repository/CommentRepository.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/repository/CommentRepository.java
@@ -2,7 +2,10 @@ package cloud.emusic.emotionmusicapi.repository;
 
 import cloud.emusic.emotionmusicapi.domain.comment.Comment;
 import cloud.emusic.emotionmusicapi.domain.post.Post;
+import cloud.emusic.emotionmusicapi.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
@@ -12,4 +15,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
   long countByPost(Post post);
 
   void deleteByPost(Post post);
+
+  long countByUserAndPostIdAndCreatedAtBetween(User user,Long postId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/CommentService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/CommentService.java
@@ -13,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,6 +29,16 @@ public class CommentService {
 
   // 댓글 생성
   public CommentResponse createComment(Long postId, CommentRequest request, User user) {
+
+    LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
+    LocalDateTime endOfDay = LocalDate.now().atTime(LocalTime.MAX);
+
+    long todayCommentCount = commentRepository.countByUserAndPostIdAndCreatedAtBetween(user,postId,startOfDay,endOfDay);
+
+    if (todayCommentCount >= 5) {
+      throw new CustomException(ErrorCode.COMMENT_LIMIT_EXCEEDED);
+    }
+
     Post post = postRepository.findById(postId)
         .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
 


### PR DESCRIPTION
## 💡 개요
- 게시글 마다 로그인 유저가 하루에 작성한 댓글 갯수를 조회하여 제한

## 🔗 관련 이슈
close #92 
