### PR TITLE
refactor: 노래 검색 API 응답 형식 리스트로 변경

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/SpotifyController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/SpotifyController.java
@@ -61,18 +61,25 @@ public class SpotifyController {
             description = "Spotify API를 이용해 곡명으로 노래를 검색합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "검색 결과 반환 성공",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = TrackResponse.class))),
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "검색 결과 반환 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            array = @ArraySchema(schema = @Schema(implementation = TrackResponse.class))
+                    )
+            ),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @GetMapping("/search")
-    public TrackResponse searchByName(
+    public List<TrackResponse> searchByName(
             @Parameter(description = "검색할 곡명", example = "Blueming")
-            @RequestParam String query
+            @RequestParam String query,
+            @Parameter(description = "검색 결과 개수", example = "50")
+            @RequestParam(defaultValue = "50") int limit
     ) {
-        return spotifyService.searchTracksByTitle(query);
+        return spotifyService.searchTracksByTitle(query,limit);
     }
 
     @Operation(


### PR DESCRIPTION
## 💡 개요
- 노래 검색 API를 정확한 곡명으로 검색할걸 전재로 변경하여 곡정보를 단일로 반환하도록 구조를 변경했음
- 유저가 키워드나 비슷한 곡명으로 검색할 수 있는 케이스도 존재함
- 그에 따른 모든 곡정보를 반환하도록 응답 형식을 변경

## 🔨 작업 내용
- 노래 검색 API 응답 형식을 여러개의 Object를 반환하도록 List 형식으로 변경
- 유저가 노래의 키워드로 검색할수도 있는 케이스를 반영 가능

## 🔗 관련 이슈
close #96 
