### PR TITLE
refactor: 감정 기반 노래 추천 로직 변경

### DIFF
--- a/.github/workflows/aws.yml
+++ b/.github/workflows/aws.yml
@@ -65,6 +65,7 @@ jobs:
             JWT_SECRET_KEY=${{ secrets.JWT_SECRET_KEY }}
             SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
             SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
+            LASTFM_API_KEY: ${{ secrets.LASTFM_API_KEY }}
 
             EOF
             

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/SpotifyController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/SpotifyController.java
@@ -53,7 +53,7 @@ public class SpotifyController {
             )
             @RequestParam(defaultValue = "10") int limit
     ) {
-        return ResponseEntity.ok(spotifyService.recommendByEmotions(emotions, limit));
+        return ResponseEntity.ok(spotifyService.searchTracksByEmotion(emotions, limit));
     }
 
     @Operation(

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/request/EmotionMapper.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/request/EmotionMapper.java
@@ -4,30 +4,39 @@ import java.util.List;
 import java.util.Map;
 
 public class EmotionMapper {
-    private static final Map<String, List<String>> emotionGenres = Map.ofEntries(
-            Map.entry("기쁨", List.of("k-pop", "dance", "idol")),
-            Map.entry("행복", List.of("k-pop", "dance")),
-            Map.entry("즐거움", List.of("k-pop", "dance")),
-            Map.entry("설렘", List.of("k-pop", "j-pop", "idol")),
-            Map.entry("두근거림", List.of("k-pop", "dance")),
-            Map.entry("놀람", List.of("k-pop", "dance")),
-            Map.entry("감동", List.of("ballad", "acoustic", "k-indie")),
-            Map.entry("화남", List.of("k-hip-hop", "rock")),
-            Map.entry("짜증", List.of("k-hip-hop", "rock")),
-            Map.entry("슬픔", List.of("ballad", "acoustic")),
-            Map.entry("우울", List.of("ballad", "acoustic")),
-            Map.entry("외로움", List.of("ballad", "acoustic")),
-            Map.entry("피곤함", List.of("lo-fi", "chill", "k-indie")),
-            Map.entry("졸림", List.of("lo-fi", "chill")),
-            Map.entry("힘듦", List.of("acoustic", "lo-fi")),
-            Map.entry("복잡함", List.of("indie", "alternative", "k-indie")),
-            Map.entry("어지러운", List.of("indie", "alternative"))
+
+    // 한글 감정 → 영어 감정
+    private static final Map<String, String> emotionEnglish = Map.ofEntries(
+            Map.entry("기쁨", "happy"),
+            Map.entry("행복", "happy"),
+            Map.entry("즐거움", "happy"),
+
+            Map.entry("설렘", "excited"),
+            Map.entry("두근거림", "excited"),
+
+            Map.entry("놀람", "surprised"),
+
+            Map.entry("감동", "emotional"),
+
+            Map.entry("화남", "angry"),
+            Map.entry("짜증", "angry"),
+
+            Map.entry("슬픔", "sad"),
+            Map.entry("우울", "sad"),
+            Map.entry("외로움", "sad"),
+
+            Map.entry("피곤함", "tired"),
+            Map.entry("졸림", "sleep"),
+            Map.entry("힘듦", "tired"),
+
+            Map.entry("복잡함", "confused"),
+            Map.entry("어지러운", "confused")
     );
 
-    public static List<String> getGenres(List<String> emotions) {
+    // 영어 감정 변환
+    public static List<String> getEnglishEmotions(List<String> emotions) {
         return emotions.stream()
-                .flatMap(e -> emotionGenres.getOrDefault(e, List.of("pop")).stream())
-                .distinct()
+                .map(e -> emotionEnglish.getOrDefault(e, "General"))
                 .toList();
     }
 }


### PR DESCRIPTION
## 🔨 작업 내용
- 각 메서드에서 사용하던 API 요청 URL을 상수로 관리하도록 리팩토링
- Spotify API 호출 시 매번 생성하던 Header를 공통 함수로 분리
- 감정 기반 노래 추천 로직을 Spotify Search API → Last.fm API 기반으로 변경
- 여러 감정을 선택했을 때 라운드 로빈 방식으로 곡을 분배
- Spotify Track ID 기준으로 중복 곡 제거 처리 적용

## 🔗 관련 이슈
close #98
