### PR TITLE
feat: 사용자가 작성한 게시글 개수,주요 감정 조회 API 구현

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
@@ -64,8 +64,12 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(auth -> auth
-            .requestMatchers("/login/url","/login/authenticate","/posts/emotion-tags","/tags/**","/songs/**").permitAll()
-            .requestMatchers("/posts/**","/users/me").authenticated()
+            .requestMatchers(
+                    "/login/url", "/login/authenticate",
+                    "/posts/emotion-tags","/tags/**",
+                    "/songs/**")
+                .permitAll()
+            .requestMatchers("/posts/**","/users/**").authenticated()
             .anyRequest().permitAll()
         )
         .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/UserController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/UserController.java
@@ -1,6 +1,7 @@
 package cloud.emusic.emotionmusicapi.controller;
 
 import cloud.emusic.emotionmusicapi.dto.response.user.UserInfoResponse;
+import cloud.emusic.emotionmusicapi.dto.response.user.UserStateResponse;
 import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
 import cloud.emusic.emotionmusicapi.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,5 +37,20 @@ public class UserController {
     @GetMapping("/me")
     public ResponseEntity<UserInfoResponse> getUserInfo(@AuthenticationPrincipal(expression = "id") Long userId) {
         return ResponseEntity.ok(userService.getUserInfo(userId));
+    }
+
+    @Operation(summary = "로그인 사용자 작성 게시글 개수,주요 감정 조회", description = "로그인한 사용자의 작성 게시글 개수와 주요 감정을 조회합니다")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = UserStateResponse.class))),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
+                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping("/state")
+    public ResponseEntity<UserStateResponse> getUserState(@AuthenticationPrincipal(expression = "id") Long userId) {
+        return ResponseEntity.ok(userService.getUserStatus(userId));
     }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/response/user/UserStateResponse.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/response/user/UserStateResponse.java
@@ -1,0 +1,27 @@
+package cloud.emusic.emotionmusicapi.dto.response.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserStateResponse {
+
+    @Schema(description = "작성한 게시글 개수", example = "1")
+    private int postCount;
+
+    @Schema(description = "주요 감정", example = "기쁨")
+    private String mostUsedEmotion;
+
+    public static UserStateResponse from(int postCount, String mostUsedEmotion) {
+        return UserStateResponse.builder()
+                .postCount(postCount)
+                .mostUsedEmotion(mostUsedEmotion)
+                .build();
+    }
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/repository/PostRepository.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/repository/PostRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     List<Post> findAllByUser(User user);
+    int countByUserId(Long userId);
 
     @Query("SELECT p FROM Post p WHERE p.user = :user AND p.createdAt >= :start AND p.createdAt < :end")
     Optional<Post> findByUserAndCreatedDate(
@@ -49,5 +50,16 @@ WHERE (:tag IS NULL OR et.emotionTag.name = :tag OR dt.name = :tag)
             @Param("tag") String tag,
             Pageable pageable
     );
+
+    @Query("""
+        SELECT et.name
+        FROM PostEmotionTag pet
+        JOIN pet.emotionTag et
+        JOIN pet.post p
+        WHERE p.user.id = :userId
+        GROUP BY et.name
+        ORDER BY COUNT(pet.id) DESC
+    """)
+    List<String> findTopEmotionTagsByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/UserService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/UserService.java
@@ -7,8 +7,10 @@ import cloud.emusic.emotionmusicapi.domain.user.UserStatus;
 import cloud.emusic.emotionmusicapi.dto.response.login.KakaoUserResponse;
 import cloud.emusic.emotionmusicapi.dto.response.login.SpotifyTokenResponse;
 import cloud.emusic.emotionmusicapi.dto.response.user.UserInfoResponse;
+import cloud.emusic.emotionmusicapi.dto.response.user.UserStateResponse;
 import cloud.emusic.emotionmusicapi.exception.CustomException;
 import cloud.emusic.emotionmusicapi.exception.dto.ErrorCode;
+import cloud.emusic.emotionmusicapi.repository.PostRepository;
 import cloud.emusic.emotionmusicapi.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +36,7 @@ public class UserService {
     private static final String SPOTIFY_ACCESS_TOKEN_URL = "https://accounts.spotify.com/api/token";
 
     private final UserRepository userRepository;
+    private final PostRepository postRepository;
     private final RestTemplate restTemplate = new RestTemplate();
 
     @Transactional
@@ -81,5 +84,17 @@ public class UserService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         return UserInfoResponse.from(user);
+    }
+
+    public UserStateResponse getUserStatus(Long userId){
+
+        int postCount = postRepository.countByUserId(userId);
+
+        String mostUsedEmotion = postRepository.findTopEmotionTagsByUserId(userId)
+                .stream()
+                .findFirst()
+                .orElse("None");
+
+        return UserStateResponse.from(postCount,mostUsedEmotion);
     }
 }


### PR DESCRIPTION
## 💡 개요
- 로그인 사용자가 작성한 게시글 개수,주요 감정을 조회하는 API를 구현
- `/users/state` 엔드포인트 사용

## 🔨 작업 내용
- PostRepository의 쿼리 메서드를 통해 작성한 게시글 조회 로직 구현
- 사용자별 주요 감정 조회 쿼리 메서드 구현
- UserService에서 게시글 수, 주요 감정 DTO 반환

## 🔗 관련 이슈
close #106
