### PR TITLE
Refactor/#108

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package cloud.emusic.emotionmusicapi.config;
 
+import cloud.emusic.emotionmusicapi.config.jwt.JwtAuthenticationEntryPoint;
 import cloud.emusic.emotionmusicapi.config.jwt.JwtAuthenticationFilter;
 import cloud.emusic.emotionmusicapi.config.jwt.JwtTokenProvider;
 import cloud.emusic.emotionmusicapi.repository.UserRepository;
@@ -28,6 +29,8 @@ import static org.springframework.security.config.Customizer.withDefaults;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
   private final JwtTokenProvider jwtTokenProvider;
   private final UserRepository userRepository;
@@ -63,6 +66,7 @@ public class SecurityConfig {
         .securityMatcher("/**")
         .csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
         .authorizeHttpRequests(auth -> auth
             .requestMatchers(
                     "/login/url", "/login/authenticate",

--- a/src/main/java/cloud/emusic/emotionmusicapi/config/SwaggerConfig.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/SwaggerConfig.java
@@ -1,12 +1,29 @@
 package cloud.emusic.emotionmusicapi.config;
 
+import cloud.emusic.emotionmusicapi.exception.ApiExceptions;
+import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
+import cloud.emusic.emotionmusicapi.exception.dto.ErrorCode;
+import cloud.emusic.emotionmusicapi.exception.dto.ExampleHolder;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Configuration
 public class SwaggerConfig {
@@ -35,5 +52,68 @@ public class SwaggerConfig {
                 .info(info)
                 .addSecurityItem(securityRequirement)
                 .components(components);
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            // 컨트롤러 메서드에서 @ApiExceptions 어노테이션 가져오기
+            ApiExceptions apiExceptions = handlerMethod.getMethodAnnotation(ApiExceptions.class);
+
+            // 에러 코드가 지정되어 있다면 Swagger 응답 예시에 추가
+            if (apiExceptions != null) {
+                generateErrorCodeResponseExample(operation, apiExceptions.values());
+            }
+
+            return operation;
+        };
+    }
+
+    // ErrorCode 배열을 받아 Swagger ApiResponses에 예시 추가
+    private void generateErrorCodeResponseExample(Operation operation, ErrorCode[] errorCodes) {
+        ApiResponses responses = operation.getResponses();
+
+        // ErrorCode 별 ExampleHolder 생성 후 상태코드별 그룹핑
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders = Arrays.stream(errorCodes)
+                .map(errorCode -> ExampleHolder.builder()
+                        .holder(getSwaggerExample(errorCode))
+                        .code(errorCode.getStatus().value())
+                        .name(errorCode.name())
+                        .build()
+                )
+                .collect(Collectors.groupingBy(ExampleHolder::getCode));
+
+        // 실제 Swagger 응답에 예시 등록
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    // 단일 ErrorCode → ErrorResponse → Swagger Example 변환
+    private Example getSwaggerExample(ErrorCode errorCode) {
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+
+        Example example = new Example();
+        example.setValue(errorResponse);
+        example.setSummary(errorCode.name());
+        return example;
+    }
+
+    // grouping된 상태코드별 예시를 Swagger ApiResponses에 등록
+    private void addExamplesToResponses(ApiResponses responses,
+                                        Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach((statusCode, exampleHolders) -> {
+            ApiResponse apiResponse = new ApiResponse().description("에러 응답");
+
+            Content content = new Content();
+            MediaType mediaType = new MediaType();
+
+            exampleHolders.forEach(holder ->
+                    mediaType.addExamples(holder.getName(), holder.getHolder())
+            );
+
+            content.addMediaType("application/json", mediaType);
+            apiResponse.setContent(content);
+
+            responses.addApiResponse(String.valueOf(statusCode), apiResponse);
+        });
     }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/config/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/config/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package cloud.emusic.emotionmusicapi.config.jwt;
+
+import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
+import cloud.emusic.emotionmusicapi.exception.dto.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        ErrorResponse error = ErrorResponse.of(ErrorCode.UNAUTHORIZED);
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(error.getStatusCode());
+        response.getWriter().write(new ObjectMapper().writeValueAsString(error));
+    }
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/CommentController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/CommentController.java
@@ -18,7 +18,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts/{postId}/comments")
-@Tag(name = "Comment API", description = "댓글 관련 API")
+@Tag(name = "Comment API", description = "댓글 관련 API 문서")
 public class CommentController {
 
   private final CommentService commentService;

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/HelloController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/HelloController.java
@@ -2,6 +2,7 @@ package cloud.emusic.emotionmusicapi.controller;
 
 import cloud.emusic.emotionmusicapi.dto.request.HelloRequest;
 import cloud.emusic.emotionmusicapi.dto.response.HelloResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/hello")
+@Tag(name = "Hello API", description = "테스트 관련 API 문서")
 public class HelloController {
     @GetMapping("/parameter")//parmeterObject
     public HelloResponse parameter(@ParameterObject HelloRequest request) {

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/LikeController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/LikeController.java
@@ -1,6 +1,7 @@
 package cloud.emusic.emotionmusicapi.controller;
 
 import cloud.emusic.emotionmusicapi.dto.response.post.PostResponse;
+import cloud.emusic.emotionmusicapi.exception.ApiExceptions;
 import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
 import cloud.emusic.emotionmusicapi.service.LikeService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,24 +18,21 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.*;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
-@Tag(name = "Like API", description = "좋아요 관련 API 문서입니다.")
+@Tag(name = "Like API", description = "좋아요 관련 API 문서")
 public class LikeController {
 
     private final LikeService likeService;
 
     @Operation(summary = "게시글 좋아요", description = "특정 게시글에 좋아요를 추가합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "좋아요 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "좋아요 성공")
     })
+    @ApiExceptions(values = {POST_NOT_FOUND,ALREADY_LIKED,UNAUTHORIZED,INTERNAL_SERVER_ERROR})
     @PostMapping("/{postId}/like")
     public ResponseEntity<Void> likePost(@PathVariable Long postId,@AuthenticationPrincipal(expression = "id") Long userId) {
         likeService.likePost(postId, userId);
@@ -43,14 +41,9 @@ public class LikeController {
 
     @Operation(summary = "게시글 좋아요 취소", description = "특정 게시글의 좋아요를 취소합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "좋아요 취소 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            @ApiResponse(responseCode = "200", description = "좋아요 취소 성공")
     })
+    @ApiExceptions(values = {POST_NOT_FOUND,LIKE_NOT_FOUND,UNAUTHORIZED,INTERNAL_SERVER_ERROR})
     @DeleteMapping("/{postId}/like")
     public ResponseEntity<Void> unlikePost(
             @PathVariable Long postId,
@@ -70,6 +63,7 @@ public class LikeController {
             @ApiResponse(responseCode = "500", description = "서버 내부 오류",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
+    @ApiExceptions(values = {UNAUTHORIZED,INTERNAL_SERVER_ERROR})
     @GetMapping("/me/likes")
     public ResponseEntity<List<PostResponse>> getMyLikedPosts(
             @AuthenticationPrincipal(expression = "id") Long userId

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/LoginController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/LoginController.java
@@ -7,8 +7,6 @@ import cloud.emusic.emotionmusicapi.dto.response.login.KakaoTokenResponse;
 import cloud.emusic.emotionmusicapi.dto.response.login.KakaoUserResponse;
 import cloud.emusic.emotionmusicapi.dto.response.login.LoginResponse;
 import cloud.emusic.emotionmusicapi.dto.response.login.SpotifyTokenResponse;
-import cloud.emusic.emotionmusicapi.exception.CustomException;
-import cloud.emusic.emotionmusicapi.exception.dto.ErrorCode;
 import cloud.emusic.emotionmusicapi.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -30,13 +28,11 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.UUID;
-
 
 @RestController
 @RequestMapping("/login")
 @RequiredArgsConstructor
-@Tag(name = "Login API", description = "소셜 로그인 관련 API")
+@Tag(name = "Login API", description = "소셜 로그인 관련 API 문서")
 public class LoginController {
 
     private final UserService userService;

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
@@ -4,7 +4,7 @@ import cloud.emusic.emotionmusicapi.dto.response.tag.EmotionTagResponse;
 import cloud.emusic.emotionmusicapi.dto.request.PostCreateRequest;
 import cloud.emusic.emotionmusicapi.dto.response.post.PostCreateResponse;
 import cloud.emusic.emotionmusicapi.dto.response.post.PostResponse;
-import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
+import cloud.emusic.emotionmusicapi.exception.ApiExceptions;
 import cloud.emusic.emotionmusicapi.service.PostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,6 +26,8 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
+import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.*;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
@@ -43,11 +45,9 @@ public class PostController {
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             array = @ArraySchema(schema = @Schema(implementation = EmotionTagResponse.class))
                     )
-            ),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
+    @ApiExceptions(values = {EMOTION_TAGS_NOT_FOUND,INTERNAL_SERVER_ERROR})
     @GetMapping("/emotion-tags")
     public ResponseEntity<List<EmotionTagResponse>> getAllEmotionTag() {
         return ResponseEntity.ok(postService.EmotionTag());
@@ -60,14 +60,9 @@ public class PostController {
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = PostCreateResponse.class)
                     )
-            ),
-            @ApiResponse(responseCode = "401", description = "인증 실패",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
-            ),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
+    @ApiExceptions(values = {UNAUTHORIZED,INTERNAL_SERVER_ERROR})
     @PostMapping
     public ResponseEntity<PostCreateResponse> create(
             @Valid @RequestBody PostCreateRequest request,
@@ -79,10 +74,9 @@ public class PostController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 목록 조회 성공",
                     content = @Content(mediaType = "application/json",
-                            array = @ArraySchema(schema = @Schema(implementation = PostResponse.class)))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                            array = @ArraySchema(schema = @Schema(implementation = PostResponse.class))))
     })
+    @ApiExceptions(values = {UNAUTHORIZED,POST_NOT_FOUND,INTERNAL_SERVER_ERROR})
     @GetMapping
     public ResponseEntity<List<PostResponse>> getAllPosts(
             @AuthenticationPrincipal(expression = "id") Long userId,
@@ -104,12 +98,9 @@ public class PostController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 조회 성공",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = PostResponse.class))),
-            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+                            schema = @Schema(implementation = PostResponse.class)))
     })
+    @ApiExceptions(values = {POST_NOT_FOUND,UNAUTHORIZED,INTERNAL_SERVER_ERROR})
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponse> getPostById(
             @PathVariable Long postId,
@@ -122,13 +113,8 @@ public class PostController {
             @ApiResponse(responseCode = "200", description = "게시글 수정 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = PostResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
+    @ApiExceptions(values = {POST_NOT_FOUND,INVALID_PERMISSION,UNAUTHORIZED,INTERNAL_SERVER_ERROR})
     @PutMapping("/{postId}")
     public ResponseEntity<PostResponse> updatePost(
             @PathVariable Long postId,
@@ -141,13 +127,8 @@ public class PostController {
     @Operation(summary = "게시글 삭제", description = "게시글 ID를 사용하여 특정 게시글을 삭제합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "게시글 삭제 성공"),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "404", description = "게시글을 찾을 수 없음",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
+    @ApiExceptions(values = {POST_NOT_FOUND,UNAUTHORIZED,INTERNAL_SERVER_ERROR})
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(
             @PathVariable Long postId,
@@ -162,11 +143,8 @@ public class PostController {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = PostResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
+    @ApiExceptions(values = {UNAUTHORIZED,INTERNAL_SERVER_ERROR})
     @GetMapping("/calendar")
     public ResponseEntity<List<PostResponse>> getMyEmotionCalendar(
             @AuthenticationPrincipal(expression = "id") Long userId
@@ -179,11 +157,8 @@ public class PostController {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = PostResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
+    @ApiExceptions(values = {UNAUTHORIZED,INTERNAL_SERVER_ERROR})
     @GetMapping("/me")
     public ResponseEntity<Object> getMyPost(
             @AuthenticationPrincipal(expression = "id") Long userId,
@@ -198,9 +173,8 @@ public class PostController {
             @ApiResponse(responseCode = "200", description = "검색 성공",
                     content = @Content(mediaType = "application/json",
                             array = @ArraySchema(schema = @Schema(implementation = PostResponse.class)))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
+    @ApiExceptions(values = {INTERNAL_SERVER_ERROR})
     @GetMapping("/search")
     public ResponseEntity<List<PostResponse>> searchPosts(
             @AuthenticationPrincipal(expression = "id") Long userId,

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/PostController.java
@@ -31,7 +31,7 @@ import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/posts")
-@Tag(name = "Post API", description = "게시글 관련 API")
+@Tag(name = "Post API", description = "게시글 관련 API 문서")
 public class PostController {
 
     private final PostService postService;

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/SpotifyController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/SpotifyController.java
@@ -1,6 +1,7 @@
 package cloud.emusic.emotionmusicapi.controller;
 
 import cloud.emusic.emotionmusicapi.dto.response.song.TrackResponse;
+import cloud.emusic.emotionmusicapi.exception.ApiExceptions;
 import cloud.emusic.emotionmusicapi.service.SpotifyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -9,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -16,9 +18,13 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.EMOTION_TAGS_NOT_FOUND;
+import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.INTERNAL_SERVER_ERROR;
+
 @RestController
 @RequestMapping("/songs")
 @RequiredArgsConstructor
+@Tag(name = "Spotify API", description = "Spotify 관련 API 문서")
 public class SpotifyController {
 
     private final SpotifyService spotifyService;
@@ -35,10 +41,9 @@ public class SpotifyController {
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             array = @ArraySchema(schema = @Schema(implementation = TrackResponse.class))
                     )
-            ),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            )
     })
+    @ApiExceptions(values = {EMOTION_TAGS_NOT_FOUND, INTERNAL_SERVER_ERROR})
     @GetMapping("/recommend")
     public ResponseEntity<List<TrackResponse>> recommend(
             @Parameter(
@@ -68,10 +73,9 @@ public class SpotifyController {
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             array = @ArraySchema(schema = @Schema(implementation = TrackResponse.class))
                     )
-            ),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 파라미터"),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            )
     })
+    @ApiExceptions(values = {INTERNAL_SERVER_ERROR})
     @GetMapping("/search")
     public List<TrackResponse> searchByName(
             @Parameter(description = "검색할 곡명", example = "Blueming")
@@ -90,9 +94,9 @@ public class SpotifyController {
             @ApiResponse(
                     responseCode = "204",
                     description = "게시글 노래 재생 횟수 증가 성공"
-            ),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+            )
     })
+    @ApiExceptions(values = {INTERNAL_SERVER_ERROR})
     @PostMapping("/{trackId}/count")
     public ResponseEntity<Void> songCountUp(@PathVariable String trackId){
         spotifyService.songCountUp(trackId);

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/TagController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/TagController.java
@@ -2,7 +2,7 @@ package cloud.emusic.emotionmusicapi.controller;
 
 import cloud.emusic.emotionmusicapi.dto.response.tag.EmotionTrackGroupResponse;
 import cloud.emusic.emotionmusicapi.dto.response.tag.TagRankingResponseWrapper;
-import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
+import cloud.emusic.emotionmusicapi.exception.ApiExceptions;
 import cloud.emusic.emotionmusicapi.service.TagService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,10 +21,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.INTERNAL_SERVER_ERROR;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/tags")
-@Tag(name = "Tag API", description = "태그 관련 API 문서입니다.")
+@Tag(name = "Tag API", description = "태그 관련 API 문서")
 public class TagController {
 
     private final TagService tagService;
@@ -38,11 +40,9 @@ public class TagController {
                             mediaType = MediaType.APPLICATION_JSON_VALUE,
                             schema = @Schema(implementation = TagRankingResponseWrapper.class)
                     )
-            ),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))
             )
     })
+    @ApiExceptions(values = INTERNAL_SERVER_ERROR)
     @GetMapping("/ranking")
     public ResponseEntity<TagRankingResponseWrapper> getAllTagRankings() {
         return ResponseEntity.ok(tagService.getTagRankings());
@@ -54,9 +54,8 @@ public class TagController {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = EmotionTrackGroupResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
+    @ApiExceptions(values = INTERNAL_SERVER_ERROR)
     @GetMapping("/song-rank")
     public ResponseEntity<List<EmotionTrackGroupResponse>> getTracksByEmotion(
             @Parameter(description = "조회할 감정 태그 이름", example = "슬픔,기쁨")

--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/UserController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/UserController.java
@@ -2,13 +2,14 @@ package cloud.emusic.emotionmusicapi.controller;
 
 import cloud.emusic.emotionmusicapi.dto.response.user.UserInfoResponse;
 import cloud.emusic.emotionmusicapi.dto.response.user.UserStateResponse;
-import cloud.emusic.emotionmusicapi.exception.ErrorResponse;
+import cloud.emusic.emotionmusicapi.exception.ApiExceptions;
 import cloud.emusic.emotionmusicapi.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,10 +17,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.INTERNAL_SERVER_ERROR;
+import static cloud.emusic.emotionmusicapi.exception.dto.ErrorCode.UNAUTHORIZED;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/users")
-@Schema(description = "유저 관련 API")
+@Tag(name = "User API", description = "유저 관련 API 문서")
 public class UserController {
 
     private final UserService userService;
@@ -29,11 +33,8 @@ public class UserController {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = UserInfoResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
+    @ApiExceptions(values = {UNAUTHORIZED,INTERNAL_SERVER_ERROR})
     @GetMapping("/me")
     public ResponseEntity<UserInfoResponse> getUserInfo(@AuthenticationPrincipal(expression = "id") Long userId) {
         return ResponseEntity.ok(userService.getUserInfo(userId));
@@ -44,11 +45,8 @@ public class UserController {
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = UserStateResponse.class))),
-            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
-            @ApiResponse(responseCode = "500", description = "서버 내부 오류",
-                    content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
     })
+    @ApiExceptions(values = {UNAUTHORIZED,INTERNAL_SERVER_ERROR})
     @GetMapping("/state")
     public ResponseEntity<UserStateResponse> getUserState(@AuthenticationPrincipal(expression = "id") Long userId) {
         return ResponseEntity.ok(userService.getUserStatus(userId));

--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/ApiExceptions.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/ApiExceptions.java
@@ -1,0 +1,14 @@
+package cloud.emusic.emotionmusicapi.exception;
+
+import cloud.emusic.emotionmusicapi.exception.dto.ErrorCode;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiExceptions {
+    ErrorCode[] values(); // API에서 발생할 수 있는 에러 코드 목록
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
 
     // 감정 태그
     EMOTION_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "감정 태그를 찾을 수 없습니다."),
+    EMOTION_TAGS_NOT_FOUND(HttpStatus.NOT_FOUND, "감정 태그들이 존재하지 않습니다."),
 
     // 댓글 (추가된 부분)
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),

--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     // 공통
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "잘못된 입력 값입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
 
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글을 찾을 수 없습니다."),
     POST_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 게시글에 접근할 권한이 없습니다."),

--- a/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ExampleHolder.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/exception/dto/ExampleHolder.java
@@ -1,0 +1,12 @@
+package cloud.emusic.emotionmusicapi.exception.dto;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.*;
+
+@Getter
+@Builder
+public class ExampleHolder {
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/PostService.java
@@ -46,9 +46,13 @@ public class PostService {
         // DB에 저장된 모든 감정 태그를 조회하여 DTO로 변환 후 반환
         // 조회 리스트를 stream으로 변환하여 map을 통해 EmotionTagResponse로 매핑
         // 최종적으로 toList()를 통해 리스트로 수집하여 반환
-        return emotionTagRepository.findAll().stream()
-            .map(tag -> new EmotionTagResponse(tag.getId(), tag.getName()))
-            .toList();
+        try {
+            return emotionTagRepository.findAll().stream()
+                    .map(tag -> new EmotionTagResponse(tag.getId(), tag.getName()))
+                    .toList();
+        } catch (Exception e) {
+            throw new CustomException(EMOTION_TAGS_NOT_FOUND);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
## 💡 개요
- API 컨트롤러 전반적으로 Swagger 문서와 예외 응답 구조를 일관되게 정리 했습니다
- 커스텀 어노테이션 @ApiExceptions 와 OperationCustomizer 를 도입하여 중복되는 Swagger 예외 문서화를 개선했습니다

## 🔨 작업 내용
- Swagger 문서화 개선
컨트롤러 메서드의 @Operation, @ApiResponse 일관성 확보
ResponseEntity<DTO> 기반으로 명세 통일

- 예외 응답 구조 표준화
@ApiExceptions 애노테이션 추가 → 발생 가능한 예외를 Swagger에 자동 반영
ExampleHolder 유틸 및 OperationCustomizer 로 Swagger 예시 JSON 자동 등록

- 보안 처리 개선
JwtAuthenticationEntryPoint 적용 → 인증 실패 시 401 JSON 응답 반환

- 각 API에 적용
게시글, 유저, 태그, 감정 태그, 스포티파이 API 컨트롤러에 @ApiExceptions 기반 예외 문서화 적용

- 리팩터링
Controller 레벨 Swagger 문서 전체적으로 일관성 있는 구조로 개선

## 📷 스크린샷 (선택)
<img width="1343" height="732" alt="image" src="https://github.com/user-attachments/assets/0f2400c2-84cb-4303-979c-5592788e8dcf" />

## 🔗 관련 이슈
close #108 
