### PR TITLE
feat: 기존 /users/state 엔드포인트 API 응답 DTO 필드 좋아요 수 추가

### DIFF
--- a/src/main/java/cloud/emusic/emotionmusicapi/controller/UserController.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/controller/UserController.java
@@ -40,7 +40,7 @@ public class UserController {
         return ResponseEntity.ok(userService.getUserInfo(userId));
     }
 
-    @Operation(summary = "로그인 사용자 작성 게시글 개수,주요 감정 조회", description = "로그인한 사용자의 작성 게시글 개수와 주요 감정을 조회합니다")
+    @Operation(summary = "로그인 사용자 작성 게시글,좋아요 개수,주요 감정 조회", description = "로그인한 사용자의 작성 게시글,좋아요 개수와 주요 감정을 조회합니다")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공",
                     content = @Content(mediaType = "application/json",

--- a/src/main/java/cloud/emusic/emotionmusicapi/dto/response/user/UserStateResponse.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/dto/response/user/UserStateResponse.java
@@ -18,10 +18,14 @@ public class UserStateResponse {
     @Schema(description = "주요 감정", example = "기쁨")
     private String mostUsedEmotion;
 
-    public static UserStateResponse from(int postCount, String mostUsedEmotion) {
+    @Schema(description = "좋아요 개수", example = "10")
+    private int likeCount;
+
+    public static UserStateResponse from(int postCount, String mostUsedEmotion, int likeCount) {
         return UserStateResponse.builder()
                 .postCount(postCount)
                 .mostUsedEmotion(mostUsedEmotion)
+                .likeCount(likeCount)
                 .build();
     }
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/repository/LikeRepository.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/repository/LikeRepository.java
@@ -4,6 +4,8 @@ import cloud.emusic.emotionmusicapi.domain.post.PostLike;
 import cloud.emusic.emotionmusicapi.domain.post.Post;
 import cloud.emusic.emotionmusicapi.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,4 +21,12 @@ public interface LikeRepository extends JpaRepository<PostLike, Long> {
     boolean existsByPostIdAndUserId(Long postId, Long userId);
 
     void deleteByPost(Post post);
+
+    @Query("""
+        SELECT COUNT(l)
+        FROM PostLike l
+        JOIN l.post p
+        WHERE p.user.id = :userId
+    """)
+    int countAllLikesByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/cloud/emusic/emotionmusicapi/service/UserService.java
+++ b/src/main/java/cloud/emusic/emotionmusicapi/service/UserService.java
@@ -10,6 +10,7 @@ import cloud.emusic.emotionmusicapi.dto.response.user.UserInfoResponse;
 import cloud.emusic.emotionmusicapi.dto.response.user.UserStateResponse;
 import cloud.emusic.emotionmusicapi.exception.CustomException;
 import cloud.emusic.emotionmusicapi.exception.dto.ErrorCode;
+import cloud.emusic.emotionmusicapi.repository.LikeRepository;
 import cloud.emusic.emotionmusicapi.repository.PostRepository;
 import cloud.emusic.emotionmusicapi.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -37,6 +38,7 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PostRepository postRepository;
+    private final LikeRepository likeRepository;
     private final RestTemplate restTemplate = new RestTemplate();
 
     @Transactional
@@ -89,12 +91,13 @@ public class UserService {
     public UserStateResponse getUserStatus(Long userId){
 
         int postCount = postRepository.countByUserId(userId);
+        int likeCount = likeRepository.countAllLikesByUserId(userId);
 
         String mostUsedEmotion = postRepository.findTopEmotionTagsByUserId(userId)
                 .stream()
                 .findFirst()
                 .orElse("None");
 
-        return UserStateResponse.from(postCount,mostUsedEmotion);
+        return UserStateResponse.from(postCount,mostUsedEmotion,likeCount);
     }
 }


### PR DESCRIPTION
## 💡 개요
- 로그인 유저가 작성한 모든 게시글의 좋아요 총 개수를 추가

## 🔨 작업 내용
- /users/state 엔드포인트 API에 응답 DTO 필드에 likeCount를 추가하여 반환
- LikeRepository의 쿼리 메서드를 구현하여 사용

## 🔗 관련 이슈
close #110
