### PR TITLE
chore: 운영 서버의 모니터링을 위한 쿼리문 로그 출력 비활성화

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -10,8 +10,8 @@ spring.datasource.password=${DB_PASSWORD}
 
 # JPA
 spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.defer-datasource-initialization=true
 
 management.endpoints.web.exposure.include: health, info, metrics, prometheus


### PR DESCRIPTION
## 💡 개요
- 현재 운영 서버에서도 쿼리문 로그가 찍히고 있음
- 많은 요청에 의해 에러 로그를 확인하기 어려움
- 쿼리문 로그는 비활성화하고 추후 에러 로그만 띄워 모니터링을 개선

## 🔨 작업 내용
- 배포 서버용 application-prod.properties SQL 로그 비활성화

## 🔗 관련 이슈
close #118